### PR TITLE
Ledger specific highlight captures

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -28,7 +28,6 @@
     "nomarket"
     "note"
     "payee"
-    "check"
     "A"
     "Y"
     "N"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,16 +1,12 @@
-[
-    (comment)
-    (note)
-] @comment
+((comment) @comment)
+((note) @comment.note)
 
-[
-    (date)
-    (interval)
-    (quantity)
-] @number
+((date) @number.date)
+((interval) @number.interval)
+((quantity) @number.quantity)
 
-((account) @field)
-((commodity) @text.literal)
+((account) @field.account)
+((commodity) @text.literal.commodity)
 
 "include" @include
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,11 +2,19 @@
 ((note) @comment.note)
 
 ((date) @number.date)
+((time) @number.time)
 ((interval) @number.interval)
 ((quantity) @number.quantity)
 
 ((account) @field.account)
 ((commodity) @text.literal.commodity)
+
+((check_in) @text.literal.check_in)
+(check_in . (date) @number.date.check_in)
+(check_in . (date) . (time) @number.time.check_in)
+((check_out) @text.literal.check_out)
+(check_out . (date) @number.date.check_out)
+(check_out . (date) . (time) @number.time.check_out)
 
 "include" @include
 


### PR DESCRIPTION

This PR adds Ledger specific suffixes to the capture group names to allow for finer grained customisation of highlights.

For example I'd like to be able to highlight the date differently from the amounts and transaction or posting metadata differently from regular file comments.

In my tests all highlights would fall-back to the defaults, e.g. `@comment.note` would be highlighted as `@comment` if `@comment.note` wasn't defined in the colorscheme.