### PR TITLE
fix: missing `const` before declarations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -199,8 +199,8 @@ module.exports = grammar({
         ),
 
         interval: $ => {
-            ci = s => new RegExp(caseInsensitive(s))
-            ciNum = s => new RegExp(caseInsensitive('every') + ' \\d+ ' + caseInsensitive(s))
+            const ci = s => new RegExp(caseInsensitive(s))
+            const ciNum = s => new RegExp(caseInsensitive('every') + ' \\d+ ' + caseInsensitive(s))
             return choice(
                 ci('every day'),
                 ci('every week'),


### PR DESCRIPTION
The grammar will fail to evaluate if JS is run in 'strict mode', since the variable assignments are assigning them as globals, which is disallowed in strict mode.