### PR TITLE
build(nix): support other common systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,18 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
   outputs = { self, nixpkgs }:
-  let
-    pkgs = nixpkgs.legacyPackages.x86_64-linux;
-  in {
-    devShells.x86_64-linux.default = pkgs.mkShellNoCC {
-      packages = [ pkgs.tree-sitter pkgs.nodejs ];
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.mkShellNoCC {
+            packages = [ pkgs.tree-sitter pkgs.nodejs ];
+          };
+        }
+      );
     };
-  };
 }


### PR DESCRIPTION
I'm not a nix user and have struggled w/ the README instructions to use `nix develop` because it never worked for me. After digging into it today, I realized that it was only set up for x86 linux (and I'm on an M4 mac). I don't use or speak nix, but Opus 4.5 suggested this change and it seems to be working and fairly minimal.

We first took a approach that used [`flake-utils`](https://github.com/numtide/flake-utils) to access `eachDefaultSystem`, but then I realized that that was only defining 4 platforms and it's not too bad to just hard code those in here. so, we backed out flake-utils and went with this approach, which seems to need 0 add'l dependencies. The list of supported systems is taken from https://github.com/numtide/flake-utils?tab=readme-ov-file#defaultsystems--system. I'm 100% open to removing some of them if you'd like. I personally only care about `aarch64-darwin`.

I tested this via `nix develop` and it successfully ran the derivation and dropped me into a bash shell. I ran `tree-sitter` and it reported version 0.24.3, which is *different* from the version that I get when I run `tree-sitter` outside of the nix shell, so i think that means it's working!