### PR TITLE
feat: support payee directive

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -167,6 +167,7 @@ module.exports = grammar({
             'format',
             $.whitespace,
             $.amount,
+            "\n",
         ),
 
         note_subdirective: $ => argumentDirective($, 'note'),

--- a/grammar.js
+++ b/grammar.js
@@ -42,6 +42,7 @@ module.exports = grammar({
             $.option,
             $.account_directive,
             $.commodity_directive,
+            $.payee_directive,
             $.tag_directive,
             seq($.word_directive, '\n'),
             seq($.char_directive, '\n'),
@@ -79,6 +80,19 @@ module.exports = grammar({
             $.format_subdirective,
             $.note_subdirective,
             singleKeywordDirective($, 'nomarket'),
+      ),
+        
+        payee_directive: $ => seq(
+            seq('payee', $.whitespace, $.payee, '\n'),
+            repeat(choice(
+                seq($.whitespace, $.comment),
+                $.payee_subdirective,
+            )),
+        ),
+
+        payee_subdirective: $ => choice(
+            $.alias_subdirective,
+            argumentDirective($, 'uuid'),
         ),
 
         tag_directive: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -399,6 +399,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "payee_directive"
+        },
+        {
+          "type": "SYMBOL",
           "name": "tag_directive"
         },
         {
@@ -631,6 +635,87 @@
             {
               "type": "STRING",
               "value": "\n"
+            }
+          ]
+        }
+      ]
+    },
+    "payee_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "payee"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "whitespace"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "payee"
+            },
+            {
+              "type": "STRING",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "whitespace"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "comment"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "payee_subdirective"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "payee_subdirective": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "alias_subdirective"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "whitespace"
+            },
+            {
+              "type": "STRING",
+              "value": "uuid"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "whitespace"
+            },
+            {
+              "type": "PATTERN",
+              "value": ".+\\n"
             }
           ]
         }
@@ -1030,6 +1115,10 @@
         {
           "type": "SYMBOL",
           "name": "amount"
+        },
+        {
+          "type": "STRING",
+          "value": "\n"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -320,6 +320,10 @@
           "named": true
         },
         {
+          "type": "payee_directive",
+          "named": true
+        },
+        {
           "type": "tag_directive",
           "named": true
         },
@@ -460,6 +464,44 @@
     "type": "option_value",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "payee_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "payee",
+          "named": true
+        },
+        {
+          "type": "payee_subdirective",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "payee_subdirective",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "alias_subdirective",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "periodic_xact",
@@ -811,11 +853,11 @@
   },
   {
     "type": "comment",
-    "named": false
+    "named": true
   },
   {
     "type": "comment",
-    "named": true
+    "named": false
   },
   {
     "type": "commodity",
@@ -916,6 +958,10 @@
   {
     "type": "time",
     "named": true
+  },
+  {
+    "type": "uuid",
+    "named": false
   },
   {
     "type": "week",

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,11 +13,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 492
+#define STATE_COUNT 478
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 166
+#define SYMBOL_COUNT 170
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 108
+#define TOKEN_COUNT 109
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 16
@@ -43,152 +43,156 @@ enum ts_symbol_identifiers {
   anon_sym_payee = 17,
   anon_sym_commodity = 18,
   anon_sym_nomarket = 19,
-  anon_sym_tag = 20,
-  aux_sym_tag_directive_token1 = 21,
-  anon_sym_include = 22,
-  anon_sym_alias = 23,
-  aux_sym_word_directive_token1 = 24,
-  anon_sym_def = 25,
-  anon_sym_year = 26,
-  aux_sym_word_directive_token2 = 27,
-  anon_sym_bucket = 28,
-  anon_sym_A = 29,
-  anon_sym_Y = 30,
-  anon_sym_N = 31,
-  anon_sym_D = 32,
-  anon_sym_C = 33,
-  anon_sym_P = 34,
-  anon_sym_default = 35,
-  anon_sym_format = 36,
-  anon_sym_note = 37,
-  anon_sym_assert = 38,
-  anon_sym_check = 39,
-  anon_sym_i = 40,
-  anon_sym_I = 41,
-  anon_sym_o = 42,
-  anon_sym_O = 43,
-  anon_sym_TILDE = 44,
-  aux_sym__interval_period_token1 = 45,
-  aux_sym__interval_period_token2 = 46,
-  aux_sym__interval_period_token3 = 47,
-  aux_sym__interval_period_token4 = 48,
-  aux_sym__interval_period_token5 = 49,
-  aux_sym__interval_period_token6 = 50,
-  aux_sym__interval_period_token7 = 51,
-  aux_sym__interval_period_token8 = 52,
-  aux_sym__interval_period_token9 = 53,
-  aux_sym__interval_period_token10 = 54,
-  aux_sym__interval_period_token11 = 55,
-  aux_sym__interval_period_token12 = 56,
-  aux_sym__interval_period_token13 = 57,
-  aux_sym__interval_period_token14 = 58,
-  aux_sym__interval_period_token15 = 59,
-  aux_sym__interval_period_token16 = 60,
-  aux_sym__interval_period_token17 = 61,
-  aux_sym__interval_date_spec_token1 = 62,
-  aux_sym__interval_date_spec_token2 = 63,
-  aux_sym__interval_date_spec_token3 = 64,
-  aux_sym__interval_date_spec_token4 = 65,
-  aux_sym__interval_date_spec_token5 = 66,
-  sym__month = 67,
-  anon_sym_last = 68,
-  anon_sym_this = 69,
-  anon_sym_next = 70,
-  anon_sym_day = 71,
-  anon_sym_week = 72,
-  anon_sym_month = 73,
-  anon_sym_quarter = 74,
-  sym__dsep = 75,
-  sym__2d = 76,
-  sym_time = 77,
-  anon_sym_STAR = 78,
-  anon_sym_BANG = 79,
-  anon_sym_LPAREN = 80,
-  aux_sym_code_token1 = 81,
-  anon_sym_RPAREN = 82,
-  sym_payee = 83,
-  sym_query = 84,
-  anon_sym_SEMI = 85,
-  aux_sym_note_token1 = 86,
-  anon_sym_LBRACK = 87,
-  anon_sym_RBRACK = 88,
-  aux_sym_note_token2 = 89,
-  sym_account_name = 90,
-  anon_sym_PLUS = 91,
-  sym__quantity = 92,
-  aux_sym_commodity_token1 = 93,
-  aux_sym_commodity_token2 = 94,
-  aux_sym_commodity_token3 = 95,
-  anon_sym_LBRACE = 96,
-  anon_sym_RBRACE = 97,
-  anon_sym_LBRACE_LBRACE = 98,
-  anon_sym_RBRACE_RBRACE = 99,
-  anon_sym_AT = 100,
-  anon_sym_AT_AT = 101,
-  anon_sym_SPACE = 102,
-  anon_sym_TAB = 103,
-  anon_sym_ = 104,
-  anon_sym_TAB2 = 105,
-  anon_sym_TAB3 = 106,
-  anon_sym_TAB_TAB = 107,
-  sym_source_file = 108,
-  sym_journal_item = 109,
-  sym_block_comment = 110,
-  sym_test = 111,
-  sym_option = 112,
-  sym_option_value = 113,
-  sym_directive = 114,
-  sym_account_directive = 115,
-  sym_account_subdirective = 116,
-  sym_commodity_directive = 117,
-  sym_commodity_subdirective = 118,
-  sym_tag_directive = 119,
-  sym_word_directive = 120,
-  sym_filename = 121,
-  sym_char_directive = 122,
-  sym_alias_subdirective = 123,
-  sym_default_subdirective = 124,
-  sym_format_subdirective = 125,
-  sym_note_subdirective = 126,
-  sym_assert_subdirective = 127,
-  sym_check_subdirective = 128,
-  sym_check_in = 129,
-  sym_check_out = 130,
-  sym_xact = 131,
-  sym_plain_xact = 132,
-  sym_periodic_xact = 133,
-  sym_interval = 134,
-  sym__interval_period = 135,
-  sym__interval_date_spec = 136,
-  sym_automated_xact = 137,
-  sym__xact_date = 138,
-  sym_date = 139,
-  sym_effective_date = 140,
-  sym_date_spec = 141,
-  sym__relative_date_spec = 142,
-  sym__4d = 143,
-  sym__single_date = 144,
-  sym_status = 145,
-  sym_code = 146,
-  sym_note = 147,
-  sym_posting = 148,
-  sym_account = 149,
-  sym_amount = 150,
-  sym_quantity = 151,
-  sym_negative_quantity = 152,
-  sym_commodity = 153,
-  sym_lot_price = 154,
-  sym_price = 155,
-  sym_balance_assertion = 156,
-  aux_sym_source_file_repeat1 = 157,
-  aux_sym_block_comment_repeat1 = 158,
-  aux_sym_account_directive_repeat1 = 159,
-  aux_sym_commodity_directive_repeat1 = 160,
-  aux_sym_tag_directive_repeat1 = 161,
-  aux_sym_plain_xact_repeat1 = 162,
-  aux_sym_note_repeat1 = 163,
-  aux_sym_note_repeat2 = 164,
-  aux_sym_whitespace_repeat1 = 165,
+  anon_sym_uuid = 20,
+  anon_sym_tag = 21,
+  aux_sym_tag_directive_token1 = 22,
+  anon_sym_include = 23,
+  anon_sym_alias = 24,
+  aux_sym_word_directive_token1 = 25,
+  anon_sym_def = 26,
+  anon_sym_year = 27,
+  aux_sym_word_directive_token2 = 28,
+  anon_sym_bucket = 29,
+  anon_sym_A = 30,
+  anon_sym_Y = 31,
+  anon_sym_N = 32,
+  anon_sym_D = 33,
+  anon_sym_C = 34,
+  anon_sym_P = 35,
+  anon_sym_default = 36,
+  anon_sym_format = 37,
+  anon_sym_note = 38,
+  anon_sym_assert = 39,
+  anon_sym_check = 40,
+  anon_sym_i = 41,
+  anon_sym_I = 42,
+  anon_sym_o = 43,
+  anon_sym_O = 44,
+  anon_sym_TILDE = 45,
+  aux_sym__interval_period_token1 = 46,
+  aux_sym__interval_period_token2 = 47,
+  aux_sym__interval_period_token3 = 48,
+  aux_sym__interval_period_token4 = 49,
+  aux_sym__interval_period_token5 = 50,
+  aux_sym__interval_period_token6 = 51,
+  aux_sym__interval_period_token7 = 52,
+  aux_sym__interval_period_token8 = 53,
+  aux_sym__interval_period_token9 = 54,
+  aux_sym__interval_period_token10 = 55,
+  aux_sym__interval_period_token11 = 56,
+  aux_sym__interval_period_token12 = 57,
+  aux_sym__interval_period_token13 = 58,
+  aux_sym__interval_period_token14 = 59,
+  aux_sym__interval_period_token15 = 60,
+  aux_sym__interval_period_token16 = 61,
+  aux_sym__interval_period_token17 = 62,
+  aux_sym__interval_date_spec_token1 = 63,
+  aux_sym__interval_date_spec_token2 = 64,
+  aux_sym__interval_date_spec_token3 = 65,
+  aux_sym__interval_date_spec_token4 = 66,
+  aux_sym__interval_date_spec_token5 = 67,
+  sym__month = 68,
+  anon_sym_last = 69,
+  anon_sym_this = 70,
+  anon_sym_next = 71,
+  anon_sym_day = 72,
+  anon_sym_week = 73,
+  anon_sym_month = 74,
+  anon_sym_quarter = 75,
+  sym__dsep = 76,
+  sym__2d = 77,
+  sym_time = 78,
+  anon_sym_STAR = 79,
+  anon_sym_BANG = 80,
+  anon_sym_LPAREN = 81,
+  aux_sym_code_token1 = 82,
+  anon_sym_RPAREN = 83,
+  sym_payee = 84,
+  sym_query = 85,
+  anon_sym_SEMI = 86,
+  aux_sym_note_token1 = 87,
+  anon_sym_LBRACK = 88,
+  anon_sym_RBRACK = 89,
+  aux_sym_note_token2 = 90,
+  sym_account_name = 91,
+  anon_sym_PLUS = 92,
+  sym__quantity = 93,
+  aux_sym_commodity_token1 = 94,
+  aux_sym_commodity_token2 = 95,
+  aux_sym_commodity_token3 = 96,
+  anon_sym_LBRACE = 97,
+  anon_sym_RBRACE = 98,
+  anon_sym_LBRACE_LBRACE = 99,
+  anon_sym_RBRACE_RBRACE = 100,
+  anon_sym_AT = 101,
+  anon_sym_AT_AT = 102,
+  anon_sym_SPACE = 103,
+  anon_sym_TAB = 104,
+  anon_sym_ = 105,
+  anon_sym_TAB2 = 106,
+  anon_sym_TAB3 = 107,
+  anon_sym_TAB_TAB = 108,
+  sym_source_file = 109,
+  sym_journal_item = 110,
+  sym_block_comment = 111,
+  sym_test = 112,
+  sym_option = 113,
+  sym_option_value = 114,
+  sym_directive = 115,
+  sym_account_directive = 116,
+  sym_account_subdirective = 117,
+  sym_commodity_directive = 118,
+  sym_commodity_subdirective = 119,
+  sym_payee_directive = 120,
+  sym_payee_subdirective = 121,
+  sym_tag_directive = 122,
+  sym_word_directive = 123,
+  sym_filename = 124,
+  sym_char_directive = 125,
+  sym_alias_subdirective = 126,
+  sym_default_subdirective = 127,
+  sym_format_subdirective = 128,
+  sym_note_subdirective = 129,
+  sym_assert_subdirective = 130,
+  sym_check_subdirective = 131,
+  sym_check_in = 132,
+  sym_check_out = 133,
+  sym_xact = 134,
+  sym_plain_xact = 135,
+  sym_periodic_xact = 136,
+  sym_interval = 137,
+  sym__interval_period = 138,
+  sym__interval_date_spec = 139,
+  sym_automated_xact = 140,
+  sym__xact_date = 141,
+  sym_date = 142,
+  sym_effective_date = 143,
+  sym_date_spec = 144,
+  sym__relative_date_spec = 145,
+  sym__4d = 146,
+  sym__single_date = 147,
+  sym_status = 148,
+  sym_code = 149,
+  sym_note = 150,
+  sym_posting = 151,
+  sym_account = 152,
+  sym_amount = 153,
+  sym_quantity = 154,
+  sym_negative_quantity = 155,
+  sym_commodity = 156,
+  sym_lot_price = 157,
+  sym_price = 158,
+  sym_balance_assertion = 159,
+  aux_sym_source_file_repeat1 = 160,
+  aux_sym_block_comment_repeat1 = 161,
+  aux_sym_account_directive_repeat1 = 162,
+  aux_sym_commodity_directive_repeat1 = 163,
+  aux_sym_payee_directive_repeat1 = 164,
+  aux_sym_tag_directive_repeat1 = 165,
+  aux_sym_plain_xact_repeat1 = 166,
+  aux_sym_note_repeat1 = 167,
+  aux_sym_note_repeat2 = 168,
+  aux_sym_whitespace_repeat1 = 169,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -212,6 +216,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_payee] = "payee",
   [anon_sym_commodity] = "commodity",
   [anon_sym_nomarket] = "nomarket",
+  [anon_sym_uuid] = "uuid",
   [anon_sym_tag] = "tag",
   [aux_sym_tag_directive_token1] = "tag_directive_token1",
   [anon_sym_include] = "include",
@@ -311,6 +316,8 @@ static const char * const ts_symbol_names[] = {
   [sym_account_subdirective] = "account_subdirective",
   [sym_commodity_directive] = "commodity_directive",
   [sym_commodity_subdirective] = "commodity_subdirective",
+  [sym_payee_directive] = "payee_directive",
+  [sym_payee_subdirective] = "payee_subdirective",
   [sym_tag_directive] = "tag_directive",
   [sym_word_directive] = "word_directive",
   [sym_filename] = "filename",
@@ -353,6 +360,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_block_comment_repeat1] = "block_comment_repeat1",
   [aux_sym_account_directive_repeat1] = "account_directive_repeat1",
   [aux_sym_commodity_directive_repeat1] = "commodity_directive_repeat1",
+  [aux_sym_payee_directive_repeat1] = "payee_directive_repeat1",
   [aux_sym_tag_directive_repeat1] = "tag_directive_repeat1",
   [aux_sym_plain_xact_repeat1] = "plain_xact_repeat1",
   [aux_sym_note_repeat1] = "note_repeat1",
@@ -381,6 +389,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_payee] = anon_sym_payee,
   [anon_sym_commodity] = anon_sym_commodity,
   [anon_sym_nomarket] = anon_sym_nomarket,
+  [anon_sym_uuid] = anon_sym_uuid,
   [anon_sym_tag] = anon_sym_tag,
   [aux_sym_tag_directive_token1] = aux_sym_tag_directive_token1,
   [anon_sym_include] = anon_sym_include,
@@ -480,6 +489,8 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_account_subdirective] = sym_account_subdirective,
   [sym_commodity_directive] = sym_commodity_directive,
   [sym_commodity_subdirective] = sym_commodity_subdirective,
+  [sym_payee_directive] = sym_payee_directive,
+  [sym_payee_subdirective] = sym_payee_subdirective,
   [sym_tag_directive] = sym_tag_directive,
   [sym_word_directive] = sym_word_directive,
   [sym_filename] = sym_filename,
@@ -522,6 +533,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_block_comment_repeat1] = aux_sym_block_comment_repeat1,
   [aux_sym_account_directive_repeat1] = aux_sym_account_directive_repeat1,
   [aux_sym_commodity_directive_repeat1] = aux_sym_commodity_directive_repeat1,
+  [aux_sym_payee_directive_repeat1] = aux_sym_payee_directive_repeat1,
   [aux_sym_tag_directive_repeat1] = aux_sym_tag_directive_repeat1,
   [aux_sym_plain_xact_repeat1] = aux_sym_plain_xact_repeat1,
   [aux_sym_note_repeat1] = aux_sym_note_repeat1,
@@ -607,6 +619,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_nomarket] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_uuid] = {
     .visible = true,
     .named = false,
   },
@@ -1006,6 +1022,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_payee_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_payee_subdirective] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_tag_directive] = {
     .visible = true,
     .named = true,
@@ -1174,6 +1198,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_payee_directive_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
   [aux_sym_tag_directive_repeat1] = {
     .visible = false,
     .named = false,
@@ -1236,7 +1264,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [15] = 15,
   [16] = 16,
   [17] = 17,
-  [18] = 10,
+  [18] = 18,
   [19] = 19,
   [20] = 20,
   [21] = 21,
@@ -1250,7 +1278,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [29] = 29,
   [30] = 30,
   [31] = 31,
-  [32] = 30,
+  [32] = 32,
   [33] = 33,
   [34] = 34,
   [35] = 35,
@@ -1283,7 +1311,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [62] = 62,
   [63] = 63,
   [64] = 64,
-  [65] = 28,
+  [65] = 65,
   [66] = 66,
   [67] = 67,
   [68] = 68,
@@ -1308,24 +1336,24 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [87] = 87,
   [88] = 88,
   [89] = 89,
-  [90] = 90,
-  [91] = 91,
+  [90] = 10,
+  [91] = 10,
   [92] = 92,
   [93] = 93,
   [94] = 94,
   [95] = 95,
   [96] = 96,
-  [97] = 97,
-  [98] = 10,
-  [99] = 10,
-  [100] = 58,
-  [101] = 13,
-  [102] = 14,
-  [103] = 11,
-  [104] = 12,
-  [105] = 10,
-  [106] = 30,
-  [107] = 28,
+  [97] = 10,
+  [98] = 98,
+  [99] = 99,
+  [100] = 100,
+  [101] = 101,
+  [102] = 102,
+  [103] = 103,
+  [104] = 104,
+  [105] = 105,
+  [106] = 106,
+  [107] = 107,
   [108] = 108,
   [109] = 109,
   [110] = 110,
@@ -1359,54 +1387,54 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [138] = 138,
   [139] = 139,
   [140] = 140,
-  [141] = 61,
-  [142] = 64,
-  [143] = 62,
+  [141] = 141,
+  [142] = 142,
+  [143] = 143,
   [144] = 144,
-  [145] = 63,
+  [145] = 10,
   [146] = 146,
-  [147] = 147,
+  [147] = 144,
   [148] = 148,
-  [149] = 149,
+  [149] = 10,
   [150] = 150,
-  [151] = 151,
-  [152] = 10,
+  [151] = 10,
+  [152] = 152,
   [153] = 153,
   [154] = 154,
-  [155] = 10,
+  [155] = 155,
   [156] = 156,
-  [157] = 10,
-  [158] = 153,
-  [159] = 153,
-  [160] = 160,
+  [157] = 157,
+  [158] = 158,
+  [159] = 159,
+  [160] = 94,
   [161] = 161,
   [162] = 162,
   [163] = 163,
-  [164] = 164,
+  [164] = 96,
   [165] = 165,
   [166] = 166,
-  [167] = 167,
-  [168] = 12,
+  [167] = 93,
+  [168] = 168,
   [169] = 169,
   [170] = 170,
   [171] = 171,
   [172] = 172,
   [173] = 173,
-  [174] = 13,
+  [174] = 157,
   [175] = 175,
-  [176] = 176,
-  [177] = 177,
+  [176] = 10,
+  [177] = 95,
   [178] = 178,
   [179] = 179,
-  [180] = 14,
+  [180] = 180,
   [181] = 181,
   [182] = 182,
   [183] = 183,
-  [184] = 11,
+  [184] = 184,
   [185] = 185,
   [186] = 186,
   [187] = 187,
-  [188] = 185,
+  [188] = 188,
   [189] = 189,
   [190] = 190,
   [191] = 191,
@@ -1427,27 +1455,27 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [206] = 206,
   [207] = 207,
   [208] = 208,
-  [209] = 191,
+  [209] = 209,
   [210] = 210,
   [211] = 211,
   [212] = 212,
   [213] = 213,
   [214] = 214,
   [215] = 215,
-  [216] = 10,
+  [216] = 216,
   [217] = 217,
   [218] = 218,
   [219] = 219,
-  [220] = 204,
+  [220] = 201,
   [221] = 221,
   [222] = 222,
-  [223] = 192,
-  [224] = 224,
+  [223] = 217,
+  [224] = 202,
   [225] = 225,
-  [226] = 224,
-  [227] = 227,
+  [226] = 226,
+  [227] = 215,
   [228] = 228,
-  [229] = 229,
+  [229] = 10,
   [230] = 230,
   [231] = 231,
   [232] = 232,
@@ -1464,11 +1492,11 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [243] = 243,
   [244] = 244,
   [245] = 245,
-  [246] = 202,
-  [247] = 233,
+  [246] = 246,
+  [247] = 247,
   [248] = 248,
-  [249] = 240,
-  [250] = 10,
+  [249] = 249,
+  [250] = 250,
   [251] = 251,
   [252] = 252,
   [253] = 253,
@@ -1479,7 +1507,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [258] = 258,
   [259] = 259,
   [260] = 260,
-  [261] = 248,
+  [261] = 226,
   [262] = 262,
   [263] = 263,
   [264] = 264,
@@ -1503,16 +1531,16 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [282] = 282,
   [283] = 283,
   [284] = 284,
-  [285] = 285,
-  [286] = 279,
+  [285] = 278,
+  [286] = 286,
   [287] = 287,
   [288] = 288,
   [289] = 289,
-  [290] = 289,
+  [290] = 290,
   [291] = 291,
-  [292] = 253,
+  [292] = 292,
   [293] = 293,
-  [294] = 291,
+  [294] = 294,
   [295] = 295,
   [296] = 296,
   [297] = 297,
@@ -1547,16 +1575,16 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [326] = 326,
   [327] = 327,
   [328] = 328,
-  [329] = 329,
+  [329] = 10,
   [330] = 330,
   [331] = 331,
   [332] = 332,
   [333] = 333,
   [334] = 334,
-  [335] = 10,
+  [335] = 335,
   [336] = 336,
   [337] = 10,
-  [338] = 338,
+  [338] = 324,
   [339] = 339,
   [340] = 340,
   [341] = 341,
@@ -1564,30 +1592,30 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [343] = 343,
   [344] = 344,
   [345] = 345,
-  [346] = 346,
-  [347] = 347,
+  [346] = 10,
+  [347] = 10,
   [348] = 348,
-  [349] = 349,
+  [349] = 10,
   [350] = 350,
   [351] = 351,
-  [352] = 352,
+  [352] = 330,
   [353] = 353,
   [354] = 354,
-  [355] = 10,
-  [356] = 10,
+  [355] = 355,
+  [356] = 356,
   [357] = 357,
-  [358] = 358,
-  [359] = 359,
-  [360] = 10,
-  [361] = 284,
+  [358] = 335,
+  [359] = 336,
+  [360] = 360,
+  [361] = 361,
   [362] = 362,
-  [363] = 357,
+  [363] = 363,
   [364] = 364,
   [365] = 365,
   [366] = 366,
-  [367] = 343,
+  [367] = 367,
   [368] = 368,
-  [369] = 344,
+  [369] = 369,
   [370] = 370,
   [371] = 371,
   [372] = 372,
@@ -1598,17 +1626,17 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [377] = 377,
   [378] = 378,
   [379] = 379,
-  [380] = 380,
+  [380] = 342,
   [381] = 381,
   [382] = 382,
-  [383] = 350,
+  [383] = 383,
   [384] = 384,
-  [385] = 351,
+  [385] = 385,
   [386] = 386,
-  [387] = 387,
-  [388] = 348,
-  [389] = 389,
-  [390] = 390,
+  [387] = 340,
+  [388] = 388,
+  [389] = 341,
+  [390] = 339,
   [391] = 391,
   [392] = 392,
   [393] = 393,
@@ -1616,33 +1644,33 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [395] = 395,
   [396] = 396,
   [397] = 397,
-  [398] = 352,
+  [398] = 398,
   [399] = 399,
-  [400] = 339,
+  [400] = 400,
   [401] = 401,
-  [402] = 402,
+  [402] = 395,
   [403] = 403,
   [404] = 404,
-  [405] = 404,
+  [405] = 405,
   [406] = 406,
-  [407] = 407,
-  [408] = 408,
+  [407] = 398,
+  [408] = 397,
   [409] = 409,
   [410] = 410,
-  [411] = 409,
-  [412] = 410,
+  [411] = 411,
+  [412] = 412,
   [413] = 413,
   [414] = 414,
   [415] = 415,
   [416] = 416,
-  [417] = 415,
-  [418] = 416,
+  [417] = 417,
+  [418] = 418,
   [419] = 419,
   [420] = 420,
   [421] = 421,
-  [422] = 421,
-  [423] = 421,
-  [424] = 413,
+  [422] = 422,
+  [423] = 423,
+  [424] = 424,
   [425] = 425,
   [426] = 426,
   [427] = 427,
@@ -1686,30 +1714,16 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [465] = 465,
   [466] = 466,
   [467] = 467,
-  [468] = 468,
+  [468] = 457,
   [469] = 469,
-  [470] = 470,
-  [471] = 471,
-  [472] = 472,
+  [470] = 426,
+  [471] = 418,
+  [472] = 466,
   [473] = 473,
   [474] = 474,
   [475] = 475,
   [476] = 476,
   [477] = 477,
-  [478] = 478,
-  [479] = 479,
-  [480] = 480,
-  [481] = 434,
-  [482] = 482,
-  [483] = 483,
-  [484] = 428,
-  [485] = 448,
-  [486] = 486,
-  [487] = 487,
-  [488] = 488,
-  [489] = 489,
-  [490] = 490,
-  [491] = 477,
 };
 
 static TSCharacterRange aux_sym_tag_directive_token1_character_set_1[] = {
@@ -1837,4230 +1851,4018 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(270);
+      if (eof) ADVANCE(278);
       ADVANCE_MAP(
-        '\t', 780,
-        '\n', 271,
-        ' ', 774,
-        '!', 559,
-        '"', 58,
-        '(', 561,
-        ')', 564,
-        '*', 557,
-        '+', 576,
-        '-', 356,
-        ';', 567,
-        '=', 361,
-        '@', 772,
-        'A', 408,
-        'B', 680,
-        'C', 424,
-        'D', 420,
-        'E', 714,
-        'F', 705,
-        'I', 448,
-        'M', 702,
-        'N', 416,
-        'O', 456,
-        'P', 428,
-        'Q', 713,
-        'T', 700,
-        'W', 674,
-        'Y', 412,
-        '[', 569,
-        ']', 571,
-        'a', 604,
-        'b', 661,
-        'c', 623,
-        'd', 579,
-        'e', 596,
-        'f', 639,
+        '\t', 739,
+        '\n', 279,
+        ' ', 733,
+        '!', 555,
+        '"', 64,
+        '(', 557,
+        ')', 560,
+        '*', 553,
+        '+', 572,
+        '-', 365,
+        ';', 563,
+        '=', 370,
+        '@', 731,
+        'A', 414,
+        'B', 679,
+        'C', 426,
+        'D', 423,
+        'E', 713,
+        'F', 704,
+        'I', 447,
+        'M', 701,
+        'N', 420,
+        'O', 453,
+        'P', 429,
+        'Q', 712,
+        'T', 699,
+        'U', 695,
+        'W', 673,
+        'Y', 417,
+        '[', 565,
+        ']', 567,
+        'a', 600,
+        'b', 659,
+        'c', 620,
+        'd', 575,
+        'e', 592,
+        'f', 637,
         'i', 443,
-        'l', 600,
-        'm', 589,
-        'n', 611,
-        'o', 452,
-        'p', 597,
-        'q', 595,
-        't', 598,
-        'w', 583,
-        'y', 584,
-        '{', 767,
-        '}', 769,
-        '~', 459,
-        'S', 682,
-        's', 682,
-        'U', 696,
-        'u', 696,
-        '.', 549,
-        '/', 549,
+        'l', 596,
+        'm', 585,
+        'n', 608,
+        'o', 450,
+        'p', 593,
+        'q', 591,
+        't', 594,
+        'u', 660,
+        'w', 579,
+        'y', 580,
+        '{', 726,
+        '}', 728,
+        '~', 455,
+        'S', 681,
+        's', 681,
+        '.', 545,
+        '/', 545,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(552);
-      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(765);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(548);
+      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(724);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 1:
       ADVANCE_MAP(
-        '\t', 780,
-        '\n', 271,
-        ' ', 774,
-        '"', 58,
-        '+', 576,
-        '-', 355,
-        ';', 567,
-        '=', 361,
-        '@', 772,
-        '{', 767,
-        '}', 769,
+        '\t', 739,
+        '\n', 279,
+        ' ', 733,
+        '"', 64,
+        '+', 572,
+        '-', 364,
+        ';', 563,
+        '=', 370,
+        '@', 731,
+        '{', 726,
+        '}', 728,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(577);
-      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(765);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(764);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(573);
+      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(724);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '\t', 780,
-        '\n', 271,
-        ' ', 774,
-        '"', 58,
-        ';', 567,
-        '=', 361,
-        '@', 772,
-        '{', 767,
-        '}', 769,
+        '\t', 739,
+        '\n', 279,
+        ' ', 733,
+        '"', 64,
+        ';', 563,
+        '=', 370,
+        '@', 731,
+        '{', 726,
+        '}', 728,
       );
-      if (('-' <= lookahead && lookahead <= '/')) ADVANCE(549);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(552);
-      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(765);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(764);
+      if (('-' <= lookahead && lookahead <= '/')) ADVANCE(545);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(548);
+      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(724);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
       END_STATE();
     case 3:
-      if (lookahead == '\t') ADVANCE(780);
-      if (lookahead == '\n') ADVANCE(271);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == ';') ADVANCE(567);
-      if (lookahead == '=') ADVANCE(361);
-      if (lookahead == ']') ADVANCE(571);
-      if (('-' <= lookahead && lookahead <= '/')) ADVANCE(549);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\t') ADVANCE(739);
+      if (lookahead == '\n') ADVANCE(279);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == ';') ADVANCE(563);
+      if (lookahead == '=') ADVANCE(370);
+      if (lookahead == ']') ADVANCE(567);
+      if (('-' <= lookahead && lookahead <= '/')) ADVANCE(545);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(271);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 4:
-      if (lookahead == '\t') ADVANCE(780);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == '!') ADVANCE(559);
-      if (lookahead == '(') ADVANCE(561);
-      if (lookahead == '*') ADVANCE(557);
+      if (lookahead == '\t') ADVANCE(739);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == '!') ADVANCE(555);
+      if (lookahead == '(') ADVANCE(557);
+      if (lookahead == '*') ADVANCE(553);
+      if (lookahead == ';') ADVANCE(563);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ';') ADVANCE(565);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(561);
       END_STATE();
     case 5:
       ADVANCE_MAP(
-        '\t', 780,
-        ' ', 774,
-        '+', 576,
-        '-', 355,
-        'D', 161,
-        'E', 245,
-        'F', 221,
-        'T', 213,
-        'a', 107,
-        'c', 99,
-        'd', 88,
-        'e', 61,
-        'f', 123,
-        'l', 70,
-        'n', 85,
-        'p', 65,
-        't', 98,
-        '}', 768,
-        'B', 188,
-        'b', 188,
-        'I', 206,
-        'i', 206,
-        'M', 216,
-        'm', 216,
-        'Q', 244,
-        'q', 244,
-        'S', 190,
-        's', 190,
-        'U', 208,
-        'u', 208,
-        'W', 178,
-        'w', 178,
-        'Y', 176,
-        'y', 176,
-        '#', 54,
-        '%', 54,
-        '*', 54,
-        ';', 54,
-        '|', 54,
+        '\t', 739,
+        ' ', 733,
+        '+', 572,
+        '-', 364,
+        'D', 170,
+        'E', 254,
+        'F', 230,
+        'T', 222,
+        'a', 115,
+        'c', 106,
+        'd', 95,
+        'e', 67,
+        'f', 131,
+        'l', 76,
+        'n', 92,
+        'p', 68,
+        't', 105,
+        '}', 163,
+        'B', 197,
+        'b', 197,
+        'I', 215,
+        'i', 215,
+        'M', 225,
+        'm', 225,
+        'Q', 253,
+        'q', 253,
+        'S', 199,
+        's', 199,
+        'U', 217,
+        'u', 217,
+        'W', 187,
+        'w', 187,
+        'Y', 185,
+        'y', 185,
+        '#', 60,
+        '%', 60,
+        '*', 60,
+        ';', 60,
+        '|', 60,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(577);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(573);
       END_STATE();
     case 6:
       ADVANCE_MAP(
-        '\t', 780,
-        ' ', 774,
-        '+', 576,
-        '-', 355,
-        'T', 50,
-        'a', 34,
-        'c', 28,
+        '\t', 739,
+        ' ', 733,
+        '+', 572,
+        '-', 364,
+        'T', 56,
+        'U', 52,
+        'a', 35,
+        'c', 29,
         'l', 22,
-        'n', 24,
-        't', 27,
-        'F', 51,
-        'f', 51,
-        'I', 48,
-        'i', 48,
-        'S', 43,
-        's', 43,
-        'U', 46,
-        'u', 46,
-        '#', 54,
-        '%', 54,
-        '*', 54,
-        ';', 54,
-        '|', 54,
+        'n', 26,
+        't', 30,
+        'u', 44,
+        'F', 57,
+        'f', 57,
+        'I', 54,
+        'i', 54,
+        'S', 49,
+        's', 49,
+        '#', 60,
+        '%', 60,
+        '*', 60,
+        ';', 60,
+        '|', 60,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(577);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(573);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(59);
       END_STATE();
     case 7:
-      if (lookahead == '\t') ADVANCE(780);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == '[') ADVANCE(569);
+      if (lookahead == '\t') ADVANCE(739);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == '[') ADVANCE(565);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(564);
+      END_STATE();
+    case 8:
+      if (lookahead == '\t') ADVANCE(739);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == 'd') ADVANCE(498);
+      if (lookahead == 'm') ADVANCE(511);
+      if (lookahead == 'q') ADVANCE(521);
+      if (lookahead == 'w') ADVANCE(505);
+      if (lookahead == 'y') ADVANCE(504);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(271);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 9:
+      if (lookahead == '\t') ADVANCE(739);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == 'l') ADVANCE(497);
+      if (lookahead == 'n') ADVANCE(501);
+      if (lookahead == 't') ADVANCE(506);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(551);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 10:
+      if (lookahead == '\t') ADVANCE(739);
+      if (lookahead == ' ') ADVANCE(733);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n') ADVANCE(568);
       END_STATE();
-    case 8:
-      if (lookahead == '\t') ADVANCE(780);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == 'd') ADVANCE(502);
-      if (lookahead == 'm') ADVANCE(515);
-      if (lookahead == 'q') ADVANCE(525);
-      if (lookahead == 'w') ADVANCE(509);
-      if (lookahead == 'y') ADVANCE(508);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 9:
-      if (lookahead == '\t') ADVANCE(780);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == 'l') ADVANCE(501);
-      if (lookahead == 'n') ADVANCE(505);
-      if (lookahead == 't') ADVANCE(510);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(555);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 10:
-      if (lookahead == '\t') ADVANCE(780);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(572);
-      END_STATE();
     case 11:
-      if (lookahead == '\t') ADVANCE(782);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == '!') ADVANCE(560);
-      if (lookahead == '(') ADVANCE(562);
-      if (lookahead == '*') ADVANCE(558);
-      if (lookahead == ';') ADVANCE(567);
-      if (lookahead == '[') ADVANCE(570);
+      if (lookahead == '\t') ADVANCE(741);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == '!') ADVANCE(556);
+      if (lookahead == '(') ADVANCE(558);
+      if (lookahead == '*') ADVANCE(554);
+      if (lookahead == ';') ADVANCE(563);
+      if (lookahead == '[') ADVANCE(566);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(575);
+          lookahead != '\n') ADVANCE(571);
       END_STATE();
     case 12:
-      if (lookahead == '\t') ADVANCE(782);
-      if (lookahead == ' ') ADVANCE(774);
-      if (lookahead == '(') ADVANCE(562);
-      if (lookahead == '[') ADVANCE(570);
+      if (lookahead == '\t') ADVANCE(741);
+      if (lookahead == ' ') ADVANCE(733);
+      if (lookahead == '(') ADVANCE(558);
+      if (lookahead == '[') ADVANCE(566);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != ';') ADVANCE(575);
+          lookahead != ';') ADVANCE(571);
       END_STATE();
     case 13:
       if (lookahead == '\t') ADVANCE(14);
-      if (lookahead == '\n') ADVANCE(271);
+      if (lookahead == '\n') ADVANCE(279);
       if (lookahead == ' ') ADVANCE(15);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(553);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(549);
       END_STATE();
     case 14:
-      if (lookahead == '\t') ADVANCE(790);
-      if (lookahead == ' ') ADVANCE(789);
+      if (lookahead == '\t') ADVANCE(749);
+      if (lookahead == ' ') ADVANCE(748);
       END_STATE();
     case 15:
-      if (lookahead == '\t') ADVANCE(788);
-      if (lookahead == ' ') ADVANCE(787);
+      if (lookahead == '\t') ADVANCE(747);
+      if (lookahead == ' ') ADVANCE(746);
       END_STATE();
     case 16:
-      if (lookahead == '\t') ADVANCE(786);
-      if (lookahead == ' ') ADVANCE(779);
+      if (lookahead == '\t') ADVANCE(740);
+      if (lookahead == ' ') ADVANCE(734);
       if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(392);
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(61);
       END_STATE();
     case 17:
-      if (lookahead == '\t') ADVANCE(781);
-      if (lookahead == ' ') ADVANCE(775);
+      if (lookahead == '\t') ADVANCE(745);
+      if (lookahead == ' ') ADVANCE(738);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(55);
+          lookahead != '=') ADVANCE(401);
       END_STATE();
     case 18:
-      if (lookahead == '\t') ADVANCE(784);
-      if (lookahead == ' ') ADVANCE(777);
+      if (lookahead == '\t') ADVANCE(743);
+      if (lookahead == ' ') ADVANCE(736);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(363);
+          lookahead != '\n') ADVANCE(372);
       END_STATE();
     case 19:
-      if (lookahead == '\t') ADVANCE(785);
-      if (lookahead == ' ') ADVANCE(778);
+      if (lookahead == '\t') ADVANCE(744);
+      if (lookahead == ' ') ADVANCE(737);
       if (lookahead != 0 &&
           lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(566);
+          lookahead != '\n') ADVANCE(562);
       END_STATE();
     case 20:
-      if (lookahead == '\n') ADVANCE(271);
-      if (lookahead == '[') ADVANCE(569);
-      if (lookahead != 0) ADVANCE(568);
+      if (lookahead == '\n') ADVANCE(279);
+      if (lookahead == '[') ADVANCE(565);
+      if (lookahead != 0) ADVANCE(564);
       END_STATE();
     case 21:
-      if (lookahead == '\n') ADVANCE(271);
-      if (lookahead != 0) ADVANCE(572);
+      if (lookahead == '\n') ADVANCE(279);
+      if (lookahead != 0) ADVANCE(568);
       END_STATE();
     case 22:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(32);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(37);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 23:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'c') ADVANCE(30);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(39);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 24:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(39);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'c') ADVANCE(34);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 25:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(23);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'd') ADVANCE(389);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 26:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(31);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(45);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 27:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'h') ADVANCE(29);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(496);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(24);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 28:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'h') ADVANCE(25);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(36);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 29:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'i') ADVANCE(33);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'h') ADVANCE(27);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 30:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'k') ADVANCE(442);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'h') ADVANCE(32);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(492);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 31:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'r') ADVANCE(38);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(25);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 32:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(36);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(38);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 33:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(535);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(23);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 34:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(35);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'k') ADVANCE(442);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 35:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(26);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'l') ADVANCE(33);
+      if (lookahead == 's') ADVANCE(40);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 36:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(531);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'r') ADVANCE(43);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 37:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(539);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(41);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 38:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(439);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(531);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 39:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'x') ADVANCE(37);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(399);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 40:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(41);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(28);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 41:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(487);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(527);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 42:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(44);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(535);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 43:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(47);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(439);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 44:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(493);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'u') ADVANCE(31);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(58);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 45:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(490);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'x') ADVANCE(42);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 46:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(52);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(47);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 47:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(40);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(483);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 48:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(500);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(50);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 49:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(45);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(53);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 50:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(496);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(489);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 51:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(49);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(486);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 52:
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(42);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(58);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 53:
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(46);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 54:
-      if (lookahead == '\n') ADVANCE(272);
-      if (lookahead != 0) ADVANCE(54);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(496);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 55:
-      if (lookahead == '\n') ADVANCE(370);
-      if (lookahead != 0) ADVANCE(55);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(51);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 56:
-      if (lookahead == ' ') ADVANCE(165);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(492);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 57:
-      if (lookahead == ' ') ADVANCE(166);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(57);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(55);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 58:
-      if (lookahead == '"') ADVANCE(766);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(58);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(48);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 59:
-      if (lookahead == ':') ADVANCE(260);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 60:
-      if (lookahead == ':') ADVANCE(261);
+      if (lookahead == '\n') ADVANCE(280);
+      if (lookahead != 0) ADVANCE(60);
       END_STATE();
     case 61:
-      if (lookahead == 'V') ADVANCE(177);
-      if (lookahead == 'v') ADVANCE(64);
+      if (lookahead == '\n') ADVANCE(378);
+      if (lookahead != 0) ADVANCE(61);
       END_STATE();
     case 62:
-      if (lookahead == 'a') ADVANCE(97);
-      if (lookahead == 'e') ADVANCE(131);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(494);
+      if (lookahead == ' ') ADVANCE(174);
       END_STATE();
     case 63:
-      if (lookahead == 'a') ADVANCE(124);
+      if (lookahead == ' ') ADVANCE(175);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
       END_STATE();
     case 64:
-      if (lookahead == 'a') ADVANCE(108);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(223);
+      if (lookahead == '"') ADVANCE(725);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(64);
       END_STATE();
     case 65:
-      if (lookahead == 'a') ADVANCE(153);
+      if (lookahead == ':') ADVANCE(269);
       END_STATE();
     case 66:
-      if (lookahead == 'a') ADVANCE(129);
+      if (lookahead == ':') ADVANCE(270);
       END_STATE();
     case 67:
-      if (lookahead == 'a') ADVANCE(149);
+      if (lookahead == 'V') ADVANCE(186);
+      if (lookahead == 'v') ADVANCE(71);
       END_STATE();
     case 68:
-      if (lookahead == 'a') ADVANCE(127);
+      if (lookahead == 'a') ADVANCE(162);
       END_STATE();
     case 69:
-      if (lookahead == 'a') ADVANCE(144);
+      if (lookahead == 'a') ADVANCE(104);
+      if (lookahead == 'e') ADVANCE(139);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(490);
       END_STATE();
     case 70:
-      if (lookahead == 'a') ADVANCE(133);
+      if (lookahead == 'a') ADVANCE(132);
       END_STATE();
     case 71:
-      if (lookahead == 'c') ADVANCE(121);
-      if (lookahead == 't') ADVANCE(80);
+      if (lookahead == 'a') ADVANCE(116);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(232);
       END_STATE();
     case 72:
-      if (lookahead == 'c') ADVANCE(75);
-      if (lookahead == 'l') ADVANCE(101);
-      if (lookahead == 's') ADVANCE(132);
+      if (lookahead == 'a') ADVANCE(137);
       END_STATE();
     case 73:
-      if (lookahead == 'c') ADVANCE(105);
+      if (lookahead == 'a') ADVANCE(157);
       END_STATE();
     case 74:
-      if (lookahead == 'c') ADVANCE(109);
+      if (lookahead == 'a') ADVANCE(135);
       END_STATE();
     case 75:
-      if (lookahead == 'c') ADVANCE(122);
+      if (lookahead == 'a') ADVANCE(151);
       END_STATE();
     case 76:
-      if (lookahead == 'c') ADVANCE(104);
+      if (lookahead == 'a') ADVANCE(141);
       END_STATE();
     case 77:
-      if (lookahead == 'd') ADVANCE(341);
+      if (lookahead == 'c') ADVANCE(129);
+      if (lookahead == 't') ADVANCE(87);
       END_STATE();
     case 78:
-      if (lookahead == 'd') ADVANCE(103);
+      if (lookahead == 'c') ADVANCE(81);
+      if (lookahead == 'l') ADVANCE(109);
+      if (lookahead == 's') ADVANCE(140);
       END_STATE();
     case 79:
-      if (lookahead == 'd') ADVANCE(84);
+      if (lookahead == 'c') ADVANCE(113);
       END_STATE();
     case 80:
-      if (lookahead == 'e') ADVANCE(128);
+      if (lookahead == 'c') ADVANCE(117);
       END_STATE();
     case 81:
-      if (lookahead == 'e') ADVANCE(118);
+      if (lookahead == 'c') ADVANCE(130);
       END_STATE();
     case 82:
-      if (lookahead == 'e') ADVANCE(95);
+      if (lookahead == 'c') ADVANCE(112);
       END_STATE();
     case 83:
-      if (lookahead == 'e') ADVANCE(63);
+      if (lookahead == 'd') ADVANCE(352);
       END_STATE();
     case 84:
-      if (lookahead == 'e') ADVANCE(384);
+      if (lookahead == 'd') ADVANCE(387);
       END_STATE();
     case 85:
-      if (lookahead == 'e') ADVANCE(151);
-      if (lookahead == 'o') ADVANCE(116);
+      if (lookahead == 'd') ADVANCE(111);
       END_STATE();
     case 86:
-      if (lookahead == 'e') ADVANCE(435);
+      if (lookahead == 'd') ADVANCE(91);
       END_STATE();
     case 87:
-      if (lookahead == 'e') ADVANCE(371);
+      if (lookahead == 'e') ADVANCE(136);
       END_STATE();
     case 88:
-      if (lookahead == 'e') ADVANCE(96);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(189);
-      END_STATE();
-    case 89:
       if (lookahead == 'e') ADVANCE(126);
       END_STATE();
+    case 89:
+      if (lookahead == 'e') ADVANCE(102);
+      END_STATE();
     case 90:
-      if (lookahead == 'e') ADVANCE(76);
+      if (lookahead == 'e') ADVANCE(379);
       END_STATE();
     case 91:
-      if (lookahead == 'e') ADVANCE(138);
+      if (lookahead == 'e') ADVANCE(394);
       END_STATE();
     case 92:
-      if (lookahead == 'e') ADVANCE(87);
+      if (lookahead == 'e') ADVANCE(160);
+      if (lookahead == 'o') ADVANCE(123);
       END_STATE();
     case 93:
-      if (lookahead == 'e') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(435);
       END_STATE();
     case 94:
-      if (lookahead == 'e') ADVANCE(120);
-      if (lookahead == 'o') ADVANCE(78);
+      if (lookahead == 'e') ADVANCE(70);
       END_STATE();
     case 95:
-      if (lookahead == 'f') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(103);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(198);
       END_STATE();
     case 96:
-      if (lookahead == 'f') ADVANCE(67);
+      if (lookahead == 'e') ADVANCE(134);
       END_STATE();
     case 97:
-      if (lookahead == 'g') ADVANCE(379);
+      if (lookahead == 'e') ADVANCE(82);
       END_STATE();
     case 98:
-      if (lookahead == 'h') ADVANCE(102);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(494);
+      if (lookahead == 'e') ADVANCE(146);
       END_STATE();
     case 99:
-      if (lookahead == 'h') ADVANCE(90);
+      if (lookahead == 'e') ADVANCE(90);
       END_STATE();
     case 100:
-      if (lookahead == 'h') ADVANCE(90);
-      if (lookahead == 'o') ADVANCE(114);
+      if (lookahead == 'e') ADVANCE(153);
       END_STATE();
     case 101:
-      if (lookahead == 'i') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(128);
+      if (lookahead == 'o') ADVANCE(85);
       END_STATE();
     case 102:
-      if (lookahead == 'i') ADVANCE(130);
+      if (lookahead == 'f') ADVANCE(402);
       END_STATE();
     case 103:
-      if (lookahead == 'i') ADVANCE(141);
+      if (lookahead == 'f') ADVANCE(73);
       END_STATE();
     case 104:
-      if (lookahead == 'k') ADVANCE(440);
+      if (lookahead == 'g') ADVANCE(390);
       END_STATE();
     case 105:
-      if (lookahead == 'k') ADVANCE(91);
+      if (lookahead == 'h') ADVANCE(110);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(490);
       END_STATE();
     case 106:
-      if (lookahead == 'k') ADVANCE(93);
+      if (lookahead == 'h') ADVANCE(97);
       END_STATE();
     case 107:
-      if (lookahead == 'l') ADVANCE(101);
-      if (lookahead == 's') ADVANCE(132);
+      if (lookahead == 'h') ADVANCE(97);
+      if (lookahead == 'o') ADVANCE(122);
       END_STATE();
     case 108:
-      if (lookahead == 'l') ADVANCE(368);
+      if (lookahead == 'i') ADVANCE(84);
       END_STATE();
     case 109:
-      if (lookahead == 'l') ADVANCE(148);
+      if (lookahead == 'i') ADVANCE(72);
       END_STATE();
     case 110:
-      if (lookahead == 'l') ADVANCE(145);
+      if (lookahead == 'i') ADVANCE(138);
       END_STATE();
     case 111:
-      if (lookahead == 'm') ADVANCE(94);
+      if (lookahead == 'i') ADVANCE(154);
       END_STATE();
     case 112:
-      if (lookahead == 'm') ADVANCE(81);
+      if (lookahead == 'k') ADVANCE(440);
       END_STATE();
     case 113:
-      if (lookahead == 'm') ADVANCE(112);
+      if (lookahead == 'k') ADVANCE(98);
       END_STATE();
     case 114:
-      if (lookahead == 'm') ADVANCE(111);
+      if (lookahead == 'k') ADVANCE(100);
       END_STATE();
     case 115:
-      if (lookahead == 'm') ADVANCE(69);
+      if (lookahead == 'l') ADVANCE(109);
+      if (lookahead == 's') ADVANCE(140);
       END_STATE();
     case 116:
-      if (lookahead == 'm') ADVANCE(68);
-      if (lookahead == 't') ADVANCE(86);
+      if (lookahead == 'l') ADVANCE(376);
       END_STATE();
     case 117:
-      if (lookahead == 'n') ADVANCE(77);
+      if (lookahead == 'l') ADVANCE(158);
       END_STATE();
     case 118:
-      if (lookahead == 'n') ADVANCE(135);
+      if (lookahead == 'l') ADVANCE(152);
       END_STATE();
     case 119:
-      if (lookahead == 'n') ADVANCE(139);
+      if (lookahead == 'm') ADVANCE(101);
       END_STATE();
     case 120:
-      if (lookahead == 'n') ADVANCE(140);
+      if (lookahead == 'm') ADVANCE(88);
       END_STATE();
     case 121:
-      if (lookahead == 'o') ADVANCE(113);
+      if (lookahead == 'm') ADVANCE(120);
       END_STATE();
     case 122:
-      if (lookahead == 'o') ADVANCE(150);
+      if (lookahead == 'm') ADVANCE(119);
       END_STATE();
     case 123:
-      if (lookahead == 'o') ADVANCE(125);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(214);
+      if (lookahead == 'm') ADVANCE(74);
+      if (lookahead == 't') ADVANCE(93);
       END_STATE();
     case 124:
-      if (lookahead == 'r') ADVANCE(397);
+      if (lookahead == 'm') ADVANCE(75);
       END_STATE();
     case 125:
-      if (lookahead == 'r') ADVANCE(115);
+      if (lookahead == 'n') ADVANCE(83);
       END_STATE();
     case 126:
-      if (lookahead == 'r') ADVANCE(137);
+      if (lookahead == 'n') ADVANCE(143);
       END_STATE();
     case 127:
-      if (lookahead == 'r') ADVANCE(106);
+      if (lookahead == 'n') ADVANCE(147);
       END_STATE();
     case 128:
-      if (lookahead == 's') ADVANCE(134);
+      if (lookahead == 'n') ADVANCE(148);
       END_STATE();
     case 129:
-      if (lookahead == 's') ADVANCE(388);
+      if (lookahead == 'o') ADVANCE(121);
       END_STATE();
     case 130:
-      if (lookahead == 's') ADVANCE(533);
+      if (lookahead == 'o') ADVANCE(159);
       END_STATE();
     case 131:
-      if (lookahead == 's') ADVANCE(136);
+      if (lookahead == 'o') ADVANCE(133);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(223);
       END_STATE();
     case 132:
-      if (lookahead == 's') ADVANCE(89);
+      if (lookahead == 'r') ADVANCE(405);
       END_STATE();
     case 133:
-      if (lookahead == 's') ADVANCE(142);
+      if (lookahead == 'r') ADVANCE(124);
       END_STATE();
     case 134:
-      if (lookahead == 't') ADVANCE(353);
+      if (lookahead == 'r') ADVANCE(145);
       END_STATE();
     case 135:
-      if (lookahead == 't') ADVANCE(347);
+      if (lookahead == 'r') ADVANCE(114);
       END_STATE();
     case 136:
-      if (lookahead == 't') ADVANCE(349);
+      if (lookahead == 's') ADVANCE(142);
       END_STATE();
     case 137:
-      if (lookahead == 't') ADVANCE(437);
+      if (lookahead == 's') ADVANCE(397);
       END_STATE();
     case 138:
-      if (lookahead == 't') ADVANCE(403);
+      if (lookahead == 's') ADVANCE(529);
       END_STATE();
     case 139:
-      if (lookahead == 't') ADVANCE(364);
+      if (lookahead == 's') ADVANCE(144);
       END_STATE();
     case 140:
-      if (lookahead == 't') ADVANCE(273);
+      if (lookahead == 's') ADVANCE(96);
       END_STATE();
     case 141:
-      if (lookahead == 't') ADVANCE(152);
+      if (lookahead == 's') ADVANCE(149);
       END_STATE();
     case 142:
-      if (lookahead == 't') ADVANCE(529);
+      if (lookahead == 't') ADVANCE(362);
       END_STATE();
     case 143:
-      if (lookahead == 't') ADVANCE(537);
+      if (lookahead == 't') ADVANCE(357);
       END_STATE();
     case 144:
-      if (lookahead == 't') ADVANCE(433);
+      if (lookahead == 't') ADVANCE(359);
       END_STATE();
     case 145:
-      if (lookahead == 't') ADVANCE(431);
+      if (lookahead == 't') ADVANCE(437);
       END_STATE();
     case 146:
-      if (lookahead == 't') ADVANCE(377);
+      if (lookahead == 't') ADVANCE(410);
       END_STATE();
     case 147:
-      if (lookahead == 'u') ADVANCE(73);
+      if (lookahead == 't') ADVANCE(373);
       END_STATE();
     case 148:
-      if (lookahead == 'u') ADVANCE(79);
+      if (lookahead == 't') ADVANCE(281);
       END_STATE();
     case 149:
-      if (lookahead == 'u') ADVANCE(110);
+      if (lookahead == 't') ADVANCE(525);
       END_STATE();
     case 150:
-      if (lookahead == 'u') ADVANCE(119);
+      if (lookahead == 't') ADVANCE(533);
       END_STATE();
     case 151:
-      if (lookahead == 'x') ADVANCE(143);
+      if (lookahead == 't') ADVANCE(433);
       END_STATE();
     case 152:
-      if (lookahead == 'y') ADVANCE(373);
+      if (lookahead == 't') ADVANCE(431);
       END_STATE();
     case 153:
-      if (lookahead == 'y') ADVANCE(92);
+      if (lookahead == 't') ADVANCE(385);
       END_STATE();
     case 154:
-      if (lookahead == '}') ADVANCE(771);
+      if (lookahead == 't') ADVANCE(161);
       END_STATE();
     case 155:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(246);
+      if (lookahead == 'u') ADVANCE(79);
       END_STATE();
     case 156:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(220);
+      if (lookahead == 'u') ADVANCE(108);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(244);
       END_STATE();
     case 157:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(247);
+      if (lookahead == 'u') ADVANCE(118);
       END_STATE();
     case 158:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(218);
+      if (lookahead == 'u') ADVANCE(86);
       END_STATE();
     case 159:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(222);
+      if (lookahead == 'u') ADVANCE(127);
       END_STATE();
     case 160:
+      if (lookahead == 'x') ADVANCE(150);
+      END_STATE();
+    case 161:
+      if (lookahead == 'y') ADVANCE(382);
+      END_STATE();
+    case 162:
+      if (lookahead == 'y') ADVANCE(99);
+      END_STATE();
+    case 163:
+      if (lookahead == '}') ADVANCE(730);
+      END_STATE();
+    case 164:
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(255);
+      END_STATE();
+    case 165:
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(229);
+      END_STATE();
+    case 166:
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(256);
+      END_STATE();
+    case 167:
       if (lookahead == 'A' ||
           lookahead == 'a') ADVANCE(227);
       END_STATE();
-    case 161:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(189);
-      END_STATE();
-    case 162:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(225);
-      END_STATE();
-    case 163:
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(226);
-      END_STATE();
-    case 164:
-      if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(168);
-      END_STATE();
-    case 165:
-      ADVANCE_MAP(
-        'D', 155,
-        'd', 155,
-        'M', 212,
-        'm', 212,
-        'Q', 242,
-        'q', 242,
-        'W', 171,
-        'w', 171,
-        'Y', 170,
-        'y', 170,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(57);
-      END_STATE();
-    case 166:
-      ADVANCE_MAP(
-        'D', 157,
-        'd', 157,
-        'M', 215,
-        'm', 215,
-        'Q', 243,
-        'q', 243,
-        'W', 174,
-        'w', 174,
-        'Y', 173,
-        'y', 173,
-      );
-      END_STATE();
-    case 167:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(191);
-      END_STATE();
     case 168:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(485);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(231);
       END_STATE();
     case 169:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(192);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(236);
       END_STATE();
     case 170:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(158);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(198);
       END_STATE();
     case 171:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(167);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(234);
       END_STATE();
     case 172:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(193);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(235);
       END_STATE();
     case 173:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(159);
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(177);
       END_STATE();
     case 174:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(169);
+      ADVANCE_MAP(
+        'D', 164,
+        'd', 164,
+        'M', 221,
+        'm', 221,
+        'Q', 251,
+        'q', 251,
+        'W', 180,
+        'w', 180,
+        'Y', 179,
+        'y', 179,
+      );
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
       END_STATE();
     case 175:
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(219);
+      ADVANCE_MAP(
+        'D', 166,
+        'd', 166,
+        'M', 224,
+        'm', 224,
+        'Q', 252,
+        'q', 252,
+        'W', 183,
+        'w', 183,
+        'Y', 182,
+        'y', 182,
+      );
       END_STATE();
     case 176:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(160);
+          lookahead == 'e') ADVANCE(200);
       END_STATE();
     case 177:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(223);
+          lookahead == 'e') ADVANCE(481);
       END_STATE();
     case 178:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(172);
+          lookahead == 'e') ADVANCE(201);
       END_STATE();
     case 179:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(224);
+          lookahead == 'e') ADVANCE(167);
       END_STATE();
     case 180:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(194);
+          lookahead == 'e') ADVANCE(176);
       END_STATE();
     case 181:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(228);
+          lookahead == 'e') ADVANCE(202);
       END_STATE();
     case 182:
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(180);
+          lookahead == 'e') ADVANCE(168);
       END_STATE();
     case 183:
-      if (lookahead == 'H' ||
-          lookahead == 'h') ADVANCE(463);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(178);
       END_STATE();
     case 184:
-      if (lookahead == 'H' ||
-          lookahead == 'h') ADVANCE(232);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(228);
       END_STATE();
     case 185:
-      if (lookahead == 'H' ||
-          lookahead == 'h') ADVANCE(199);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(169);
       END_STATE();
     case 186:
-      if (lookahead == 'H' ||
-          lookahead == 'h') ADVANCE(201);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(232);
       END_STATE();
     case 187:
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(195);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(181);
       END_STATE();
     case 188:
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(233);
+      END_STATE();
+    case 189:
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(203);
+      END_STATE();
+    case 190:
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(237);
+      END_STATE();
+    case 191:
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(189);
+      END_STATE();
+    case 192:
+      if (lookahead == 'H' ||
+          lookahead == 'h') ADVANCE(459);
+      END_STATE();
+    case 193:
+      if (lookahead == 'H' ||
+          lookahead == 'h') ADVANCE(241);
+      END_STATE();
+    case 194:
+      if (lookahead == 'H' ||
+          lookahead == 'h') ADVANCE(208);
+      END_STATE();
+    case 195:
+      if (lookahead == 'H' ||
+          lookahead == 'h') ADVANCE(210);
+      END_STATE();
+    case 196:
       if (lookahead == 'I' ||
           lookahead == 'i') ADVANCE(204);
       END_STATE();
-    case 189:
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(196);
-      END_STATE();
-    case 190:
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(207);
-      END_STATE();
-    case 191:
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(462);
-      END_STATE();
-    case 192:
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(230);
-      END_STATE();
-    case 193:
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(197);
-      END_STATE();
-    case 194:
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(200);
-      END_STATE();
-    case 195:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(491);
-      END_STATE();
-    case 196:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(248);
-      END_STATE();
     case 197:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(250);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(213);
       END_STATE();
     case 198:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(251);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(205);
       END_STATE();
     case 199:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(252);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(216);
       END_STATE();
     case 200:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(253);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(458);
       END_STATE();
     case 201:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(254);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(239);
       END_STATE();
     case 202:
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(255);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(206);
       END_STATE();
     case 203:
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(488);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(209);
       END_STATE();
     case 204:
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(217);
-      if (lookahead == 'W' ||
-          lookahead == 'w') ADVANCE(182);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(487);
       END_STATE();
     case 205:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(234);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(257);
       END_STATE();
     case 206:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(497);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(259);
       END_STATE();
     case 207:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(164);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(260);
       END_STATE();
     case 208:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(235);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(261);
       END_STATE();
     case 209:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(236);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(262);
       END_STATE();
     case 210:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(237);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(263);
       END_STATE();
     case 211:
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(241);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(264);
       END_STATE();
     case 212:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(205);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(484);
       END_STATE();
     case 213:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(494);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(226);
+      if (lookahead == 'W' ||
+          lookahead == 'w') ADVANCE(191);
       END_STATE();
     case 214:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(203);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(243);
       END_STATE();
     case 215:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(209);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(493);
       END_STATE();
     case 216:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(210);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(173);
       END_STATE();
     case 217:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(211);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(244);
       END_STATE();
     case 218:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(465);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(245);
       END_STATE();
     case 219:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(464);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(246);
       END_STATE();
     case 220:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(238);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(250);
       END_STATE();
     case 221:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(214);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(214);
       END_STATE();
     case 222:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(231);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(490);
       END_STATE();
     case 223:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(249);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(212);
       END_STATE();
     case 224:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(233);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(218);
       END_STATE();
     case 225:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(239);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(219);
       END_STATE();
     case 226:
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(240);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(220);
       END_STATE();
     case 227:
       if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(198);
+          lookahead == 'r') ADVANCE(461);
       END_STATE();
     case 228:
       if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(202);
+          lookahead == 'r') ADVANCE(460);
       END_STATE();
     case 229:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(247);
+      END_STATE();
+    case 230:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(223);
+      END_STATE();
+    case 231:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(240);
+      END_STATE();
+    case 232:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(258);
+      END_STATE();
+    case 233:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(242);
+      END_STATE();
+    case 234:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(248);
+      END_STATE();
+    case 235:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(249);
+      END_STATE();
+    case 236:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(207);
+      END_STATE();
+    case 237:
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(211);
+      END_STATE();
+    case 238:
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(462);
+      END_STATE();
+    case 239:
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(463);
+      END_STATE();
+    case 240:
       if (lookahead == 'S' ||
           lookahead == 's') ADVANCE(466);
       END_STATE();
-    case 230:
+    case 241:
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(467);
+          lookahead == 's') ADVANCE(464);
       END_STATE();
-    case 231:
+    case 242:
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(470);
+          lookahead == 's') ADVANCE(465);
       END_STATE();
-    case 232:
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(468);
-      END_STATE();
-    case 233:
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(469);
-      END_STATE();
-    case 234:
+    case 243:
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(183);
+          lookahead == 't') ADVANCE(192);
       END_STATE();
-    case 235:
+    case 244:
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(187);
+          lookahead == 't') ADVANCE(196);
       END_STATE();
-    case 236:
+    case 245:
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(193);
+      END_STATE();
+    case 246:
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(194);
+      END_STATE();
+    case 247:
       if (lookahead == 'T' ||
           lookahead == 't') ADVANCE(184);
       END_STATE();
-    case 237:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(185);
-      END_STATE();
-    case 238:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(175);
-      END_STATE();
-    case 239:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(179);
-      END_STATE();
-    case 240:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(181);
-      END_STATE();
-    case 241:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(186);
-      END_STATE();
-    case 242:
-      if (lookahead == 'U' ||
-          lookahead == 'u') ADVANCE(156);
-      END_STATE();
-    case 243:
-      if (lookahead == 'U' ||
-          lookahead == 'u') ADVANCE(162);
-      END_STATE();
-    case 244:
-      if (lookahead == 'U' ||
-          lookahead == 'u') ADVANCE(163);
-      END_STATE();
-    case 245:
-      if (lookahead == 'V' ||
-          lookahead == 'v') ADVANCE(177);
-      END_STATE();
-    case 246:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(461);
-      END_STATE();
-    case 247:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(229);
-      END_STATE();
     case 248:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(471);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(188);
       END_STATE();
     case 249:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(56);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(190);
       END_STATE();
     case 250:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(473);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(195);
       END_STATE();
     case 251:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(483);
+      if (lookahead == 'U' ||
+          lookahead == 'u') ADVANCE(165);
       END_STATE();
     case 252:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(477);
+      if (lookahead == 'U' ||
+          lookahead == 'u') ADVANCE(171);
       END_STATE();
     case 253:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(475);
+      if (lookahead == 'U' ||
+          lookahead == 'u') ADVANCE(172);
       END_STATE();
     case 254:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(479);
+      if (lookahead == 'V' ||
+          lookahead == 'v') ADVANCE(186);
       END_STATE();
     case 255:
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(481);
+          lookahead == 'y') ADVANCE(457);
       END_STATE();
     case 256:
-      if (lookahead == ' ' ||
-          lookahead == ',' ||
-          lookahead == '.') ADVANCE(256);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(577);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(238);
       END_STATE();
     case 257:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(402);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(467);
       END_STATE();
     case 258:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(62);
       END_STATE();
     case 259:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(556);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(469);
       END_STATE();
     case 260:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(479);
       END_STATE();
     case 261:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(259);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(473);
       END_STATE();
     case 262:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(471);
       END_STATE();
     case 263:
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(575);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(475);
       END_STATE();
     case 264:
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(574);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(477);
       END_STATE();
     case 265:
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ' &&
-          lookahead != ';') ADVANCE(575);
+      if (lookahead == ' ' ||
+          lookahead == ',' ||
+          lookahead == '.') ADVANCE(265);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(573);
       END_STATE();
     case 266:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(409);
+      END_STATE();
+    case 267:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(66);
+      END_STATE();
+    case 268:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(552);
+      END_STATE();
+    case 269:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(267);
+      END_STATE();
+    case 270:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(268);
+      END_STATE();
+    case 271:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(65);
+      END_STATE();
+    case 272:
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(571);
+      END_STATE();
+    case 273:
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(570);
+      END_STATE();
+    case 274:
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '=') ADVANCE(360);
-      END_STATE();
-    case 267:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(363);
-      END_STATE();
-    case 268:
-      if (eof) ADVANCE(270);
-      ADVANCE_MAP(
-        '\t', 780,
-        '\n', 271,
-        ' ', 774,
-        '"', 58,
-        '-', 356,
-        '=', 361,
-        'A', 409,
-        'C', 425,
-        'D', 421,
-        'I', 449,
-        'N', 417,
-        'O', 457,
-        'P', 429,
-        'Y', 413,
-        'a', 727,
-        'b', 761,
-        'c', 750,
-        'd', 734,
-        'e', 747,
-        'i', 445,
-        'o', 453,
-        't', 724,
-        'y', 735,
-        '~', 459,
-        '#', 54,
-        '%', 54,
-        '*', 54,
-        ';', 54,
-        '|', 54,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(555);
-      if (set_contains(aux_sym_commodity_token2_character_set_1, 18, lookahead)) ADVANCE(765);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 269:
-      if (eof) ADVANCE(270);
-      ADVANCE_MAP(
-        '\t', 780,
-        '\n', 271,
-        ' ', 774,
-        '-', 356,
-        '=', 361,
-        'A', 407,
-        'C', 423,
-        'D', 419,
-        'I', 447,
-        'N', 415,
-        'O', 455,
-        'P', 427,
-        'T', 213,
-        'Y', 411,
-        'a', 72,
-        'b', 147,
-        'c', 100,
-        'd', 82,
-        'e', 117,
-        'i', 444,
-        'o', 451,
-        't', 62,
-        'y', 83,
-        '}', 154,
-        '~', 459,
-        'U', 208,
-        'u', 208,
-        '#', 54,
-        '%', 54,
-        '*', 54,
-        ';', 54,
-        '|', 54,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(555);
-      END_STATE();
-    case 270:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 271:
-      ACCEPT_TOKEN(anon_sym_LF);
-      END_STATE();
-    case 272:
-      ACCEPT_TOKEN(sym_comment);
-      END_STATE();
-    case 273:
-      ACCEPT_TOKEN(anon_sym_comment);
-      END_STATE();
-    case 274:
-      ACCEPT_TOKEN(anon_sym_comment);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead != ';') ADVANCE(571);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(anon_sym_comment);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != ' ' &&
+          lookahead != '=') ADVANCE(369);
       END_STATE();
     case 276:
-      ACCEPT_TOKEN(anon_sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(372);
       END_STATE();
     case 277:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == '\t') ADVANCE(783);
-      if (lookahead == '\n') ADVANCE(271);
-      if (lookahead == ' ') ADVANCE(776);
-      if (lookahead == 'e') ADVANCE(313);
-      if (lookahead != 0) ADVANCE(339);
+      if (eof) ADVANCE(278);
+      ADVANCE_MAP(
+        '\t', 739,
+        '\n', 279,
+        ' ', 733,
+        '-', 365,
+        '=', 370,
+        'A', 413,
+        'C', 425,
+        'D', 422,
+        'I', 446,
+        'N', 419,
+        'O', 452,
+        'P', 428,
+        'T', 222,
+        'U', 217,
+        'Y', 416,
+        'a', 78,
+        'b', 155,
+        'c', 107,
+        'd', 89,
+        'e', 125,
+        'i', 444,
+        'o', 449,
+        'p', 68,
+        't', 69,
+        'u', 156,
+        'y', 94,
+        '}', 727,
+        '~', 455,
+        '#', 60,
+        '%', 60,
+        '*', 60,
+        ';', 60,
+        '|', 60,
+      );
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(551);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == '\t') ADVANCE(783);
-      if (lookahead == '\n') ADVANCE(271);
-      if (lookahead == ' ') ADVANCE(776);
-      if (lookahead == 'e') ADVANCE(315);
-      if (lookahead != 0) ADVANCE(339);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == '\t') ADVANCE(783);
-      if (lookahead == ' ') ADVANCE(776);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
     case 280:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == '\n') ADVANCE(272);
-      if (lookahead != 0) ADVANCE(280);
+      ACCEPT_TOKEN(sym_comment);
       END_STATE();
     case 281:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'a') ADVANCE(302);
-      if (lookahead == 'e') ADVANCE(321);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_comment);
       END_STATE();
     case 282:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'a') ADVANCE(320);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_comment);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'a') ADVANCE(322);
+      ACCEPT_TOKEN(anon_sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 284:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'c') ADVANCE(287);
-      if (lookahead == 'l') ADVANCE(303);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      if (lookahead == '\t') ADVANCE(742);
+      if (lookahead == '\n') ADVANCE(279);
+      if (lookahead == ' ') ADVANCE(735);
+      if (lookahead == 'e') ADVANCE(323);
+      if (lookahead != 0) ADVANCE(350);
       END_STATE();
     case 285:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'c') ADVANCE(305);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      if (lookahead == '\t') ADVANCE(742);
+      if (lookahead == '\n') ADVANCE(279);
+      if (lookahead == ' ') ADVANCE(735);
+      if (lookahead == 'e') ADVANCE(325);
+      if (lookahead != 0) ADVANCE(350);
       END_STATE();
     case 286:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'c') ADVANCE(306);
+      if (lookahead == '\t') ADVANCE(742);
+      if (lookahead == ' ') ADVANCE(735);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 287:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'c') ADVANCE(318);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      if (lookahead == '\n') ADVANCE(280);
+      if (lookahead != 0) ADVANCE(287);
       END_STATE();
     case 288:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'c') ADVANCE(319);
+      if (lookahead == 'a') ADVANCE(346);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 289:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'd') ADVANCE(346);
+      if (lookahead == 'a') ADVANCE(312);
+      if (lookahead == 'e') ADVANCE(331);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 290:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'd') ADVANCE(343);
+      if (lookahead == 'a') ADVANCE(330);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 291:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'd') ADVANCE(304);
+      if (lookahead == 'a') ADVANCE(332);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 292:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'd') ADVANCE(344);
+      if (lookahead == 'c') ADVANCE(295);
+      if (lookahead == 'l') ADVANCE(313);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 293:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'd') ADVANCE(296);
+      if (lookahead == 'c') ADVANCE(315);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 294:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(301);
+      if (lookahead == 'c') ADVANCE(316);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 295:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(282);
+      if (lookahead == 'c') ADVANCE(328);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 296:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(387);
+      if (lookahead == 'c') ADVANCE(329);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 297:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(325);
+      if (lookahead == 'd') ADVANCE(356);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 298:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(323);
+      if (lookahead == 'd') ADVANCE(354);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 299:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(314);
-      if (lookahead == 'o') ADVANCE(291);
+      if (lookahead == 'd') ADVANCE(314);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 300:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'e') ADVANCE(316);
+      if (lookahead == 'd') ADVANCE(355);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 301:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'f') ADVANCE(396);
+      if (lookahead == 'd') ADVANCE(304);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 302:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'g') ADVANCE(382);
+      if (lookahead == 'e') ADVANCE(311);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 303:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'i') ADVANCE(283);
+      if (lookahead == 'e') ADVANCE(381);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 304:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'i') ADVANCE(328);
+      if (lookahead == 'e') ADVANCE(396);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 305:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'k') ADVANCE(297);
+      if (lookahead == 'e') ADVANCE(290);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'l') ADVANCE(334);
+      if (lookahead == 'e') ADVANCE(335);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 307:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'm') ADVANCE(299);
+      if (lookahead == 'e') ADVANCE(303);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 308:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'm') ADVANCE(307);
+      if (lookahead == 'e') ADVANCE(333);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 309:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'm') ADVANCE(310);
+      if (lookahead == 'e') ADVANCE(324);
+      if (lookahead == 'o') ADVANCE(299);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 310:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'm') ADVANCE(300);
+      if (lookahead == 'e') ADVANCE(326);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 311:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'n') ADVANCE(289);
+      if (lookahead == 'f') ADVANCE(404);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 312:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'n') ADVANCE(326);
+      if (lookahead == 'g') ADVANCE(392);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 313:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'n') ADVANCE(290);
+      if (lookahead == 'i') ADVANCE(291);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 314:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'n') ADVANCE(327);
+      if (lookahead == 'i') ADVANCE(340);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 315:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'n') ADVANCE(292);
+      if (lookahead == 'k') ADVANCE(306);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 316:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'n') ADVANCE(329);
+      if (lookahead == 'l') ADVANCE(344);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 317:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'o') ADVANCE(308);
+      if (lookahead == 'm') ADVANCE(309);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 318:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'o') ADVANCE(332);
+      if (lookahead == 'm') ADVANCE(317);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 319:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'o') ADVANCE(309);
+      if (lookahead == 'm') ADVANCE(320);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 320:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'r') ADVANCE(401);
+      if (lookahead == 'm') ADVANCE(310);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 321:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 's') ADVANCE(324);
+      if (lookahead == 'n') ADVANCE(297);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 322:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 's') ADVANCE(391);
+      if (lookahead == 'n') ADVANCE(336);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 323:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 's') ADVANCE(330);
+      if (lookahead == 'n') ADVANCE(298);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 324:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(352);
+      if (lookahead == 'n') ADVANCE(337);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 325:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(406);
+      if (lookahead == 'n') ADVANCE(300);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 326:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(367);
+      if (lookahead == 'n') ADVANCE(338);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 327:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(276);
+      if (lookahead == 'o') ADVANCE(318);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 328:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(335);
+      if (lookahead == 'o') ADVANCE(342);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 329:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(348);
+      if (lookahead == 'o') ADVANCE(319);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 330:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(354);
+      if (lookahead == 'r') ADVANCE(408);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 331:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 't') ADVANCE(298);
+      if (lookahead == 's') ADVANCE(334);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 332:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'u') ADVANCE(312);
+      if (lookahead == 's') ADVANCE(400);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 333:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'u') ADVANCE(285);
+      if (lookahead == 's') ADVANCE(339);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 334:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'u') ADVANCE(293);
+      if (lookahead == 't') ADVANCE(361);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 335:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (lookahead == 'y') ADVANCE(376);
+      if (lookahead == 't') ADVANCE(412);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 336:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(339);
+      if (lookahead == 't') ADVANCE(375);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 337:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(336);
+      if (lookahead == 't') ADVANCE(283);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 338:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(337);
+      if (lookahead == 't') ADVANCE(358);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 339:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 't') ADVANCE(363);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 340:
       ACCEPT_TOKEN(aux_sym_block_comment_token1);
-      if (eof) ADVANCE(270);
-      ADVANCE_MAP(
-        '\n', 271,
-        '-', 357,
-        '=', 362,
-        'A', 410,
-        'C', 426,
-        'D', 422,
-        'I', 450,
-        'N', 418,
-        'O', 458,
-        'P', 430,
-        'Y', 414,
-        'a', 284,
-        'b', 333,
-        'c', 317,
-        'd', 294,
-        'e', 311,
-        'i', 446,
-        'o', 454,
-        't', 281,
-        'y', 295,
-        '~', 460,
-        '#', 280,
-        '%', 280,
-        '*', 280,
-        ';', 280,
-        '|', 280,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(338);
-      if (lookahead != 0) ADVANCE(339);
+      if (lookahead == 't') ADVANCE(345);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 341:
-      ACCEPT_TOKEN(anon_sym_end);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 't') ADVANCE(308);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 342:
-      ACCEPT_TOKEN(anon_sym_end);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == ' ') ADVANCE(71);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 'u') ADVANCE(322);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 343:
-      ACCEPT_TOKEN(anon_sym_end);
-      if (lookahead == ' ') ADVANCE(288);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 'u') ADVANCE(293);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 344:
-      ACCEPT_TOKEN(anon_sym_end);
-      if (lookahead == ' ') ADVANCE(331);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 'u') ADVANCE(301);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 345:
-      ACCEPT_TOKEN(anon_sym_end);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 'y') ADVANCE(384);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 346:
-      ACCEPT_TOKEN(anon_sym_end);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead == 'y') ADVANCE(307);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 347:
-      ACCEPT_TOKEN(anon_sym_endcomment);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(350);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 348:
-      ACCEPT_TOKEN(anon_sym_endcomment);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(347);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 349:
-      ACCEPT_TOKEN(anon_sym_test);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(348);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 350:
-      ACCEPT_TOKEN(anon_sym_test);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 351:
-      ACCEPT_TOKEN(anon_sym_test);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(aux_sym_block_comment_token1);
+      if (eof) ADVANCE(278);
+      ADVANCE_MAP(
+        '\n', 279,
+        '-', 366,
+        '=', 371,
+        'A', 415,
+        'C', 427,
+        'D', 424,
+        'I', 448,
+        'N', 421,
+        'O', 454,
+        'P', 430,
+        'Y', 418,
+        'a', 292,
+        'b', 343,
+        'c', 327,
+        'd', 302,
+        'e', 321,
+        'i', 445,
+        'o', 451,
+        'p', 288,
+        't', 289,
+        'y', 305,
+        '~', 456,
+        '#', 287,
+        '%', 287,
+        '*', 287,
+        ';', 287,
+        '|', 287,
+      );
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(349);
+      if (lookahead != 0) ADVANCE(350);
       END_STATE();
     case 352:
-      ACCEPT_TOKEN(anon_sym_test);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_end);
       END_STATE();
     case 353:
-      ACCEPT_TOKEN(anon_sym_endtest);
+      ACCEPT_TOKEN(anon_sym_end);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == ' ') ADVANCE(77);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 354:
-      ACCEPT_TOKEN(anon_sym_endtest);
+      ACCEPT_TOKEN(anon_sym_end);
+      if (lookahead == ' ') ADVANCE(296);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 355:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_end);
+      if (lookahead == ' ') ADVANCE(341);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 356:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '-') ADVANCE(358);
+      ACCEPT_TOKEN(anon_sym_end);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 357:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '-') ADVANCE(359);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_endcomment);
       END_STATE();
     case 358:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH);
+      ACCEPT_TOKEN(anon_sym_endcomment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 359:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_test);
       END_STATE();
     case 360:
+      ACCEPT_TOKEN(anon_sym_test);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(anon_sym_test);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(anon_sym_endtest);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(anon_sym_endtest);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '-') ADVANCE(367);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '-') ADVANCE(368);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(anon_sym_DASH_DASH);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(anon_sym_DASH_DASH);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
+      END_STATE();
+    case 369:
       ACCEPT_TOKEN(aux_sym_option_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != ' ' &&
-          lookahead != '=') ADVANCE(360);
-      END_STATE();
-    case 361:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      END_STATE();
-    case 362:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 363:
-      ACCEPT_TOKEN(aux_sym_option_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(363);
-      END_STATE();
-    case 364:
-      ACCEPT_TOKEN(anon_sym_account);
-      END_STATE();
-    case 365:
-      ACCEPT_TOKEN(anon_sym_account);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
-      END_STATE();
-    case 366:
-      ACCEPT_TOKEN(anon_sym_account);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 367:
-      ACCEPT_TOKEN(anon_sym_account);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 368:
-      ACCEPT_TOKEN(anon_sym_eval);
-      END_STATE();
-    case 369:
-      ACCEPT_TOKEN(anon_sym_eval);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead != '=') ADVANCE(369);
       END_STATE();
     case 370:
-      ACCEPT_TOKEN(aux_sym_account_subdirective_token1);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 371:
-      ACCEPT_TOKEN(anon_sym_payee);
+      ACCEPT_TOKEN(anon_sym_EQ);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 372:
-      ACCEPT_TOKEN(anon_sym_payee);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym_option_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(372);
       END_STATE();
     case 373:
-      ACCEPT_TOKEN(anon_sym_commodity);
+      ACCEPT_TOKEN(anon_sym_account);
       END_STATE();
     case 374:
-      ACCEPT_TOKEN(anon_sym_commodity);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_account);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 375:
-      ACCEPT_TOKEN(anon_sym_commodity);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_account);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 376:
-      ACCEPT_TOKEN(anon_sym_commodity);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_eval);
       END_STATE();
     case 377:
-      ACCEPT_TOKEN(anon_sym_nomarket);
+      ACCEPT_TOKEN(anon_sym_eval);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 378:
-      ACCEPT_TOKEN(anon_sym_nomarket);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym_account_subdirective_token1);
       END_STATE();
     case 379:
-      ACCEPT_TOKEN(anon_sym_tag);
+      ACCEPT_TOKEN(anon_sym_payee);
       END_STATE();
     case 380:
-      ACCEPT_TOKEN(anon_sym_tag);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_payee);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 381:
-      ACCEPT_TOKEN(anon_sym_tag);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_payee);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 382:
-      ACCEPT_TOKEN(anon_sym_tag);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_commodity);
       END_STATE();
     case 383:
-      ACCEPT_TOKEN(aux_sym_tag_directive_token1);
+      ACCEPT_TOKEN(anon_sym_commodity);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 384:
-      ACCEPT_TOKEN(anon_sym_include);
+      ACCEPT_TOKEN(anon_sym_commodity);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 385:
-      ACCEPT_TOKEN(anon_sym_include);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_nomarket);
       END_STATE();
     case 386:
-      ACCEPT_TOKEN(anon_sym_include);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_nomarket);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 387:
-      ACCEPT_TOKEN(anon_sym_include);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_uuid);
       END_STATE();
     case 388:
-      ACCEPT_TOKEN(anon_sym_alias);
+      ACCEPT_TOKEN(anon_sym_uuid);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 389:
-      ACCEPT_TOKEN(anon_sym_alias);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_uuid);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 390:
-      ACCEPT_TOKEN(anon_sym_alias);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_tag);
       END_STATE();
     case 391:
-      ACCEPT_TOKEN(anon_sym_alias);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_tag);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 392:
-      ACCEPT_TOKEN(aux_sym_word_directive_token1);
+      ACCEPT_TOKEN(anon_sym_tag);
       if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(392);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 393:
-      ACCEPT_TOKEN(anon_sym_def);
+      ACCEPT_TOKEN(aux_sym_tag_directive_token1);
       END_STATE();
     case 394:
-      ACCEPT_TOKEN(anon_sym_def);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(663);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_include);
       END_STATE();
     case 395:
-      ACCEPT_TOKEN(anon_sym_def);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_include);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 396:
-      ACCEPT_TOKEN(anon_sym_def);
+      ACCEPT_TOKEN(anon_sym_include);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 397:
-      ACCEPT_TOKEN(anon_sym_year);
+      ACCEPT_TOKEN(anon_sym_alias);
       END_STATE();
     case 398:
-      ACCEPT_TOKEN(anon_sym_year);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(718);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_alias);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 399:
-      ACCEPT_TOKEN(anon_sym_year);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_alias);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 400:
+      ACCEPT_TOKEN(anon_sym_alias);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
+      END_STATE();
+    case 401:
+      ACCEPT_TOKEN(aux_sym_word_directive_token1);
+      if (lookahead != 0 &&
+          lookahead != '=') ADVANCE(401);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(anon_sym_def);
+      END_STATE();
+    case 403:
+      ACCEPT_TOKEN(anon_sym_def);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(661);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(anon_sym_def);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
+      END_STATE();
+    case 405:
+      ACCEPT_TOKEN(anon_sym_year);
+      END_STATE();
+    case 406:
+      ACCEPT_TOKEN(anon_sym_year);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(717);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 407:
       ACCEPT_TOKEN(anon_sym_year);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 401:
-      ACCEPT_TOKEN(anon_sym_year);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 402:
-      ACCEPT_TOKEN(aux_sym_word_directive_token2);
-      END_STATE();
-    case 403:
-      ACCEPT_TOKEN(anon_sym_bucket);
-      END_STATE();
-    case 404:
-      ACCEPT_TOKEN(anon_sym_bucket);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
-      END_STATE();
-    case 405:
-      ACCEPT_TOKEN(anon_sym_bucket);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 406:
-      ACCEPT_TOKEN(anon_sym_bucket);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 407:
-      ACCEPT_TOKEN(anon_sym_A);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 408:
-      ACCEPT_TOKEN(anon_sym_A);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_year);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 409:
-      ACCEPT_TOKEN(anon_sym_A);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(aux_sym_word_directive_token2);
       END_STATE();
     case 410:
-      ACCEPT_TOKEN(anon_sym_A);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_bucket);
       END_STATE();
     case 411:
-      ACCEPT_TOKEN(anon_sym_Y);
+      ACCEPT_TOKEN(anon_sym_bucket);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 412:
-      ACCEPT_TOKEN(anon_sym_Y);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(669);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_bucket);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 413:
-      ACCEPT_TOKEN(anon_sym_Y);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_A);
       END_STATE();
     case 414:
-      ACCEPT_TOKEN(anon_sym_Y);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_A);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 415:
-      ACCEPT_TOKEN(anon_sym_N);
+      ACCEPT_TOKEN(anon_sym_A);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 416:
-      ACCEPT_TOKEN(anon_sym_N);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_Y);
       END_STATE();
     case 417:
-      ACCEPT_TOKEN(anon_sym_N);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_Y);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(668);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 418:
-      ACCEPT_TOKEN(anon_sym_N);
+      ACCEPT_TOKEN(anon_sym_Y);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 419:
-      ACCEPT_TOKEN(anon_sym_D);
+      ACCEPT_TOKEN(anon_sym_N);
       END_STATE();
     case 420:
-      ACCEPT_TOKEN(anon_sym_D);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(681);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_N);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 421:
-      ACCEPT_TOKEN(anon_sym_D);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_N);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 422:
       ACCEPT_TOKEN(anon_sym_D);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
       END_STATE();
     case 423:
-      ACCEPT_TOKEN(anon_sym_C);
+      ACCEPT_TOKEN(anon_sym_D);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(680);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 424:
-      ACCEPT_TOKEN(anon_sym_C);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_D);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 425:
       ACCEPT_TOKEN(anon_sym_C);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
       END_STATE();
     case 426:
       ACCEPT_TOKEN(anon_sym_C);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 427:
-      ACCEPT_TOKEN(anon_sym_P);
+      ACCEPT_TOKEN(anon_sym_C);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 428:
       ACCEPT_TOKEN(anon_sym_P);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
       END_STATE();
     case 429:
       ACCEPT_TOKEN(anon_sym_P);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 430:
       ACCEPT_TOKEN(anon_sym_P);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 431:
       ACCEPT_TOKEN(anon_sym_default);
       END_STATE();
     case 432:
       ACCEPT_TOKEN(anon_sym_default);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 433:
       ACCEPT_TOKEN(anon_sym_format);
       END_STATE();
     case 434:
       ACCEPT_TOKEN(anon_sym_format);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 435:
       ACCEPT_TOKEN(anon_sym_note);
       END_STATE();
     case 436:
       ACCEPT_TOKEN(anon_sym_note);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 437:
       ACCEPT_TOKEN(anon_sym_assert);
       END_STATE();
     case 438:
       ACCEPT_TOKEN(anon_sym_assert);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 439:
       ACCEPT_TOKEN(anon_sym_assert);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 440:
       ACCEPT_TOKEN(anon_sym_check);
       END_STATE();
     case 441:
       ACCEPT_TOKEN(anon_sym_check);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 442:
       ACCEPT_TOKEN(anon_sym_check);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 443:
       ACCEPT_TOKEN(anon_sym_i);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N') ADVANCE(499);
-      if (lookahead == 'n') ADVANCE(498);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N') ADVANCE(495);
+      if (lookahead == 'n') ADVANCE(494);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 444:
       ACCEPT_TOKEN(anon_sym_i);
-      if (lookahead == 'n') ADVANCE(74);
+      if (lookahead == 'n') ADVANCE(80);
       END_STATE();
     case 445:
       ACCEPT_TOKEN(anon_sym_i);
-      if (lookahead == 'n') ADVANCE(729);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      if (lookahead == 'n') ADVANCE(294);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 446:
-      ACCEPT_TOKEN(anon_sym_i);
-      if (lookahead == 'n') ADVANCE(286);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_I);
       END_STATE();
     case 447:
       ACCEPT_TOKEN(anon_sym_I);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(495);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 448:
       ACCEPT_TOKEN(anon_sym_I);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(499);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 449:
-      ACCEPT_TOKEN(anon_sym_I);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_o);
       END_STATE();
     case 450:
-      ACCEPT_TOKEN(anon_sym_I);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+      ACCEPT_TOKEN(anon_sym_o);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 451:
       ACCEPT_TOKEN(anon_sym_o);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 452:
-      ACCEPT_TOKEN(anon_sym_o);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_O);
       END_STATE();
     case 453:
-      ACCEPT_TOKEN(anon_sym_o);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
+      ACCEPT_TOKEN(anon_sym_O);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 454:
-      ACCEPT_TOKEN(anon_sym_o);
+      ACCEPT_TOKEN(anon_sym_O);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 455:
-      ACCEPT_TOKEN(anon_sym_O);
+      ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
     case 456:
-      ACCEPT_TOKEN(anon_sym_O);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
     case 457:
-      ACCEPT_TOKEN(anon_sym_O);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 458:
-      ACCEPT_TOKEN(anon_sym_O);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 459:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      END_STATE();
-    case 460:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 461:
       ACCEPT_TOKEN(aux_sym__interval_period_token1);
       END_STATE();
-    case 462:
+    case 458:
       ACCEPT_TOKEN(aux_sym__interval_period_token2);
       END_STATE();
-    case 463:
+    case 459:
       ACCEPT_TOKEN(aux_sym__interval_period_token3);
       END_STATE();
-    case 464:
+    case 460:
       ACCEPT_TOKEN(aux_sym__interval_period_token4);
       END_STATE();
-    case 465:
+    case 461:
       ACCEPT_TOKEN(aux_sym__interval_period_token5);
       END_STATE();
-    case 466:
+    case 462:
       ACCEPT_TOKEN(aux_sym__interval_period_token6);
       END_STATE();
-    case 467:
+    case 463:
       ACCEPT_TOKEN(aux_sym__interval_period_token7);
       END_STATE();
-    case 468:
+    case 464:
       ACCEPT_TOKEN(aux_sym__interval_period_token8);
       END_STATE();
-    case 469:
+    case 465:
       ACCEPT_TOKEN(aux_sym__interval_period_token9);
       END_STATE();
-    case 470:
+    case 466:
       ACCEPT_TOKEN(aux_sym__interval_period_token10);
       END_STATE();
-    case 471:
+    case 467:
       ACCEPT_TOKEN(aux_sym__interval_period_token11);
+      END_STATE();
+    case 468:
+      ACCEPT_TOKEN(aux_sym__interval_period_token11);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 469:
+      ACCEPT_TOKEN(aux_sym__interval_period_token12);
+      END_STATE();
+    case 470:
+      ACCEPT_TOKEN(aux_sym__interval_period_token12);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 471:
+      ACCEPT_TOKEN(aux_sym__interval_period_token13);
       END_STATE();
     case 472:
-      ACCEPT_TOKEN(aux_sym__interval_period_token11);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_period_token13);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 473:
-      ACCEPT_TOKEN(aux_sym__interval_period_token12);
+      ACCEPT_TOKEN(aux_sym__interval_period_token14);
       END_STATE();
     case 474:
-      ACCEPT_TOKEN(aux_sym__interval_period_token12);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_period_token14);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 475:
-      ACCEPT_TOKEN(aux_sym__interval_period_token13);
+      ACCEPT_TOKEN(aux_sym__interval_period_token15);
       END_STATE();
     case 476:
-      ACCEPT_TOKEN(aux_sym__interval_period_token13);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_period_token15);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 477:
-      ACCEPT_TOKEN(aux_sym__interval_period_token14);
+      ACCEPT_TOKEN(aux_sym__interval_period_token16);
       END_STATE();
     case 478:
-      ACCEPT_TOKEN(aux_sym__interval_period_token14);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_period_token16);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 479:
-      ACCEPT_TOKEN(aux_sym__interval_period_token15);
+      ACCEPT_TOKEN(aux_sym__interval_period_token17);
       END_STATE();
     case 480:
-      ACCEPT_TOKEN(aux_sym__interval_period_token15);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_period_token17);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 481:
-      ACCEPT_TOKEN(aux_sym__interval_period_token16);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token1);
       END_STATE();
     case 482:
-      ACCEPT_TOKEN(aux_sym__interval_period_token16);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token1);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 483:
-      ACCEPT_TOKEN(aux_sym__interval_period_token17);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token1);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 484:
-      ACCEPT_TOKEN(aux_sym__interval_period_token17);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token2);
       END_STATE();
     case 485:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token1);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token2);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 486:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token2);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 487:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token3);
       END_STATE();
     case 488:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token2);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token3);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 489:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token2);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token3);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 490:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token2);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token4);
       END_STATE();
     case 491:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token3);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token4);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 492:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token3);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token4);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 493:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token3);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
       END_STATE();
     case 494:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token4);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'c') ADVANCE(629);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 495:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token4);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 496:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token4);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 497:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'a') ADVANCE(515);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 498:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'c') ADVANCE(631);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'a') ADVANCE(523);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 499:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'a') ADVANCE(514);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 500:
-      ACCEPT_TOKEN(aux_sym__interval_date_spec_token5);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'a') ADVANCE(512);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 501:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'a') ADVANCE(519);
+      if (lookahead == 'e') ADVANCE(522);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 502:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'a') ADVANCE(527);
+      if (lookahead == 'e') ADVANCE(509);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 503:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'a') ADVANCE(518);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 504:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'a') ADVANCE(516);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 505:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'e') ADVANCE(526);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 506:
       ACCEPT_TOKEN(sym__month);
       if (lookahead == 'e') ADVANCE(513);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 504:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'e') ADVANCE(500);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 505:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'e') ADVANCE(502);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 506:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'h') ADVANCE(508);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 507:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'e') ADVANCE(517);
+      if (lookahead == 'h') ADVANCE(542);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 508:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'e') ADVANCE(504);
+      if (lookahead == 'i') ADVANCE(516);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 509:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'e') ADVANCE(506);
+      if (lookahead == 'k') ADVANCE(540);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 510:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'h') ADVANCE(512);
+      if (lookahead == 'n') ADVANCE(519);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 511:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'h') ADVANCE(546);
+      if (lookahead == 'o') ADVANCE(510);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 512:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'i') ADVANCE(520);
+      if (lookahead == 'r') ADVANCE(407);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 513:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'k') ADVANCE(544);
+      if (lookahead == 'r') ADVANCE(544);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 514:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'n') ADVANCE(523);
+      if (lookahead == 'r') ADVANCE(520);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 515:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'o') ADVANCE(514);
+      if (lookahead == 's') ADVANCE(517);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 516:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'r') ADVANCE(400);
+      if (lookahead == 's') ADVANCE(532);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 517:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'r') ADVANCE(548);
+      if (lookahead == 't') ADVANCE(528);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 518:
       ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'r') ADVANCE(524);
+      if (lookahead == 't') ADVANCE(536);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 519:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 's') ADVANCE(521);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 520:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 's') ADVANCE(536);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 521:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 't') ADVANCE(532);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 522:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 't') ADVANCE(540);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 523:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 't') ADVANCE(511);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
-      END_STATE();
-    case 524:
       ACCEPT_TOKEN(sym__month);
       if (lookahead == 't') ADVANCE(507);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 520:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 't') ADVANCE(503);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 521:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'u') ADVANCE(499);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 522:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'x') ADVANCE(518);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 523:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead == 'y') ADVANCE(538);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
+      END_STATE();
+    case 524:
+      ACCEPT_TOKEN(sym__month);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 525:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'u') ADVANCE(503);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+      ACCEPT_TOKEN(anon_sym_last);
       END_STATE();
     case 526:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'x') ADVANCE(522);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+      ACCEPT_TOKEN(anon_sym_last);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 527:
-      ACCEPT_TOKEN(sym__month);
-      if (lookahead == 'y') ADVANCE(542);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+      ACCEPT_TOKEN(anon_sym_last);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 528:
-      ACCEPT_TOKEN(sym__month);
+      ACCEPT_TOKEN(anon_sym_last);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 529:
-      ACCEPT_TOKEN(anon_sym_last);
+      ACCEPT_TOKEN(anon_sym_this);
       END_STATE();
     case 530:
-      ACCEPT_TOKEN(anon_sym_last);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_this);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 531:
-      ACCEPT_TOKEN(anon_sym_last);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(anon_sym_this);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 532:
-      ACCEPT_TOKEN(anon_sym_last);
+      ACCEPT_TOKEN(anon_sym_this);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 533:
-      ACCEPT_TOKEN(anon_sym_this);
+      ACCEPT_TOKEN(anon_sym_next);
       END_STATE();
     case 534:
-      ACCEPT_TOKEN(anon_sym_this);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_next);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 535:
-      ACCEPT_TOKEN(anon_sym_this);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(anon_sym_next);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(59);
       END_STATE();
     case 536:
-      ACCEPT_TOKEN(anon_sym_this);
+      ACCEPT_TOKEN(anon_sym_next);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 537:
-      ACCEPT_TOKEN(anon_sym_next);
+      ACCEPT_TOKEN(anon_sym_day);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 538:
-      ACCEPT_TOKEN(anon_sym_next);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_day);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 539:
-      ACCEPT_TOKEN(anon_sym_next);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(53);
+      ACCEPT_TOKEN(anon_sym_week);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(716);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 540:
-      ACCEPT_TOKEN(anon_sym_next);
+      ACCEPT_TOKEN(anon_sym_week);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 541:
-      ACCEPT_TOKEN(anon_sym_day);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(anon_sym_month);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(718);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 542:
-      ACCEPT_TOKEN(anon_sym_day);
+      ACCEPT_TOKEN(anon_sym_month);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 543:
-      ACCEPT_TOKEN(anon_sym_week);
-      if (lookahead == '\n') ADVANCE(383);
+      ACCEPT_TOKEN(anon_sym_quarter);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(717);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'l') ADVANCE(721);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 544:
-      ACCEPT_TOKEN(anon_sym_week);
+      ACCEPT_TOKEN(anon_sym_quarter);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+          (lookahead < '0' || '9' < lookahead)) ADVANCE(524);
       END_STATE();
     case 545:
-      ACCEPT_TOKEN(anon_sym_month);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(719);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(sym__dsep);
       END_STATE();
     case 546:
-      ACCEPT_TOKEN(anon_sym_month);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+      ACCEPT_TOKEN(sym__2d);
       END_STATE();
     case 547:
-      ACCEPT_TOKEN(anon_sym_quarter);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(722);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      ACCEPT_TOKEN(sym__2d);
+      if (lookahead == ':') ADVANCE(269);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
       END_STATE();
     case 548:
-      ACCEPT_TOKEN(anon_sym_quarter);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ' &&
-          (lookahead < '0' || '9' < lookahead)) ADVANCE(528);
+      ACCEPT_TOKEN(sym__2d);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(547);
       END_STATE();
     case 549:
-      ACCEPT_TOKEN(sym__dsep);
+      ACCEPT_TOKEN(sym__2d);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(546);
       END_STATE();
     case 550:
       ACCEPT_TOKEN(sym__2d);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
       END_STATE();
     case 551:
       ACCEPT_TOKEN(sym__2d);
-      if (lookahead == ':') ADVANCE(260);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
-      END_STATE();
-    case 552:
-      ACCEPT_TOKEN(sym__2d);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(551);
-      END_STATE();
-    case 553:
-      ACCEPT_TOKEN(sym__2d);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(550);
       END_STATE();
-    case 554:
-      ACCEPT_TOKEN(sym__2d);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
-      END_STATE();
-    case 555:
-      ACCEPT_TOKEN(sym__2d);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(554);
-      END_STATE();
-    case 556:
+    case 552:
       ACCEPT_TOKEN(sym_time);
       END_STATE();
-    case 557:
+    case 553:
       ACCEPT_TOKEN(anon_sym_STAR);
+      END_STATE();
+    case 554:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(569);
+      END_STATE();
+    case 555:
+      ACCEPT_TOKEN(anon_sym_BANG);
+      END_STATE();
+    case 556:
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(569);
+      END_STATE();
+    case 557:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 558:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(573);
+          lookahead != ' ') ADVANCE(569);
       END_STATE();
     case 559:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      END_STATE();
-    case 560:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(573);
-      END_STATE();
-    case 561:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 562:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(573);
-      END_STATE();
-    case 563:
       ACCEPT_TOKEN(aux_sym_code_token1);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(563);
+          lookahead != ')') ADVANCE(559);
       END_STATE();
-    case 564:
+    case 560:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 565:
+    case 561:
       ACCEPT_TOKEN(sym_payee);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != ';') ADVANCE(565);
+          lookahead != ';') ADVANCE(561);
       END_STATE();
-    case 566:
+    case 562:
       ACCEPT_TOKEN(sym_query);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(566);
+          lookahead != '\n') ADVANCE(562);
       END_STATE();
-    case 567:
+    case 563:
       ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
-    case 568:
+    case 564:
       ACCEPT_TOKEN(aux_sym_note_token1);
       END_STATE();
-    case 569:
+    case 565:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
-    case 570:
+    case 566:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(573);
+          lookahead != ' ') ADVANCE(569);
       END_STATE();
-    case 571:
+    case 567:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 572:
+    case 568:
       ACCEPT_TOKEN(aux_sym_note_token2);
       END_STATE();
-    case 573:
+    case 569:
       ACCEPT_TOKEN(sym_account_name);
-      if (lookahead == ' ') ADVANCE(264);
+      if (lookahead == ' ') ADVANCE(273);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(573);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(569);
       END_STATE();
-    case 574:
+    case 570:
       ACCEPT_TOKEN(sym_account_name);
-      if (lookahead == ' ') ADVANCE(263);
+      if (lookahead == ' ') ADVANCE(272);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(573);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(569);
       END_STATE();
-    case 575:
+    case 571:
       ACCEPT_TOKEN(sym_account_name);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(573);
+          lookahead != ' ') ADVANCE(569);
       END_STATE();
-    case 576:
+    case 572:
       ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
-    case 577:
+    case 573:
       ACCEPT_TOKEN(sym__quantity);
       if (lookahead == ' ' ||
           lookahead == ',' ||
-          lookahead == '.') ADVANCE(256);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(577);
+          lookahead == '.') ADVANCE(265);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(573);
+      END_STATE();
+    case 574:
+      ACCEPT_TOKEN(aux_sym_commodity_token1);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == ' ') ADVANCE(174);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 575:
+      ACCEPT_TOKEN(aux_sym_commodity_token1);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'A') ADVANCE(680);
+      if (lookahead == 'a') ADVANCE(664);
+      if (lookahead == 'e') ADVANCE(618);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 576:
+      ACCEPT_TOKEN(aux_sym_commodity_token1);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'A') ADVANCE(705);
+      if (lookahead == 'a') ADVANCE(586);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
+      END_STATE();
+    case 577:
+      ACCEPT_TOKEN(aux_sym_commodity_token1);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'A') ADVANCE(706);
+      if (lookahead == 'a') ADVANCE(587);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 578:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == ' ') ADVANCE(165);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E') ADVANCE(683);
+      if (lookahead == 'e') ADVANCE(583);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 579:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'A') ADVANCE(681);
-      if (lookahead == 'a') ADVANCE(665);
-      if (lookahead == 'e') ADVANCE(621);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E') ADVANCE(670);
+      if (lookahead == 'e') ADVANCE(578);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 580:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'A') ADVANCE(706);
-      if (lookahead == 'a') ADVANCE(590);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E') ADVANCE(668);
+      if (lookahead == 'e') ADVANCE(577);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 581:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'A') ADVANCE(707);
-      if (lookahead == 'a') ADVANCE(591);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E') ADVANCE(707);
+      if (lookahead == 'e') ADVANCE(588);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 582:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E') ADVANCE(684);
-      if (lookahead == 'e') ADVANCE(587);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'H') ADVANCE(689);
+      if (lookahead == 'h') ADVANCE(541);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 583:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E') ADVANCE(671);
-      if (lookahead == 'e') ADVANCE(582);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'K') ADVANCE(687);
+      if (lookahead == 'k') ADVANCE(539);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 584:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E') ADVANCE(669);
-      if (lookahead == 'e') ADVANCE(581);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N') ADVANCE(708);
+      if (lookahead == 'n') ADVANCE(589);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 585:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E') ADVANCE(708);
-      if (lookahead == 'e') ADVANCE(592);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'O') ADVANCE(697);
+      if (lookahead == 'o') ADVANCE(584);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 586:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'H') ADVANCE(690);
-      if (lookahead == 'h') ADVANCE(545);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'R') ADVANCE(710);
+      if (lookahead == 'r') ADVANCE(590);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 587:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'K') ADVANCE(688);
-      if (lookahead == 'k') ADVANCE(543);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'R') ADVANCE(688);
+      if (lookahead == 'r') ADVANCE(406);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 588:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N') ADVANCE(709);
-      if (lookahead == 'n') ADVANCE(593);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'R') ADVANCE(692);
+      if (lookahead == 'r') ADVANCE(543);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 589:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'O') ADVANCE(698);
-      if (lookahead == 'o') ADVANCE(588);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'T') ADVANCE(677);
+      if (lookahead == 't') ADVANCE(582);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 590:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'R') ADVANCE(711);
-      if (lookahead == 'r') ADVANCE(594);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'T') ADVANCE(676);
+      if (lookahead == 't') ADVANCE(581);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 591:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'R') ADVANCE(689);
-      if (lookahead == 'r') ADVANCE(398);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'U') ADVANCE(667);
+      if (lookahead == 'u') ADVANCE(576);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 592:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'R') ADVANCE(693);
-      if (lookahead == 'r') ADVANCE(547);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'V') ADVANCE(672);
+      if (lookahead == 'n') ADVANCE(604);
+      if (lookahead == 'v') ADVANCE(595);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 593:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'T') ADVANCE(678);
-      if (lookahead == 't') ADVANCE(586);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(666);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 594:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'T') ADVANCE(677);
-      if (lookahead == 't') ADVANCE(585);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(619);
+      if (lookahead == 'e') ADVANCE(646);
+      if (lookahead == 'h') ADVANCE(622);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(491);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 595:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'U') ADVANCE(668);
-      if (lookahead == 'u') ADVANCE(580);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(628);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(703);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 596:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'V') ADVANCE(673);
-      if (lookahead == 'n') ADVANCE(608);
-      if (lookahead == 'v') ADVANCE(599);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(642);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 597:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(667);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(641);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 598:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(622);
-      if (lookahead == 'e') ADVANCE(648);
-      if (lookahead == 'h') ADVANCE(624);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(495);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(644);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 599:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(630);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(704);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'a') ADVANCE(652);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 600:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(644);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'c') ADVANCE(601);
+      if (lookahead == 'l') ADVANCE(624);
+      if (lookahead == 's') ADVANCE(645);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 601:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(643);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'c') ADVANCE(638);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 602:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(646);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'c') ADVANCE(626);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 603:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'a') ADVANCE(654);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'c') ADVANCE(625);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 604:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'c') ADVANCE(605);
-      if (lookahead == 'l') ADVANCE(626);
-      if (lookahead == 's') ADVANCE(647);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'd') ADVANCE(353);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 605:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'c') ADVANCE(640);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'd') ADVANCE(388);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 606:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'c') ADVANCE(628);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'd') ADVANCE(623);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 607:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'c') ADVANCE(627);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'd') ADVANCE(611);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 608:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'd') ADVANCE(342);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(663);
+      if (lookahead == 'o') ADVANCE(633);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 609:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'd') ADVANCE(625);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(436);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 610:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'd') ADVANCE(614);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(380);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 611:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(664);
-      if (lookahead == 'o') ADVANCE(635);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(395);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 612:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(436);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(640);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 613:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(372);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(603);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 614:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(385);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(651);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 615:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(642);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(610);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 616:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(607);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(656);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 617:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(653);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'e') ADVANCE(636);
+      if (lookahead == 'o') ADVANCE(606);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 618:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(613);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'f') ADVANCE(403);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 619:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(658);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'g') ADVANCE(391);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 620:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'e') ADVANCE(638);
-      if (lookahead == 'o') ADVANCE(609);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'h') ADVANCE(613);
+      if (lookahead == 'o') ADVANCE(632);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 621:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'f') ADVANCE(394);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(605);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 622:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'g') ADVANCE(380);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(643);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 623:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'h') ADVANCE(616);
-      if (lookahead == 'o') ADVANCE(634);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(657);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 624:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'i') ADVANCE(645);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'i') ADVANCE(598);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 625:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'i') ADVANCE(659);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'k') ADVANCE(441);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 626:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'i') ADVANCE(602);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'k') ADVANCE(614);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 627:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'k') ADVANCE(441);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'k') ADVANCE(616);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 628:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'k') ADVANCE(617);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'l') ADVANCE(377);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 629:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'k') ADVANCE(619);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'l') ADVANCE(662);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 630:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'l') ADVANCE(369);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'l') ADVANCE(655);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 631:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'l') ADVANCE(662);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'm') ADVANCE(617);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 632:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'l') ADVANCE(657);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'm') ADVANCE(631);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 633:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'm') ADVANCE(620);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'm') ADVANCE(597);
+      if (lookahead == 't') ADVANCE(609);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 634:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'm') ADVANCE(633);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'm') ADVANCE(599);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 635:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'm') ADVANCE(601);
-      if (lookahead == 't') ADVANCE(612);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'n') ADVANCE(653);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 636:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'm') ADVANCE(603);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'n') ADVANCE(654);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 637:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'n') ADVANCE(655);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'o') ADVANCE(639);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(700);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 638:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'n') ADVANCE(656);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'o') ADVANCE(658);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 639:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'o') ADVANCE(641);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(701);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'r') ADVANCE(634);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 640:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'o') ADVANCE(660);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'r') ADVANCE(650);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 641:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'r') ADVANCE(636);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'r') ADVANCE(627);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 642:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'r') ADVANCE(652);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(647);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 643:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'r') ADVANCE(629);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(530);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 644:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(649);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(398);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 645:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(534);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(612);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 646:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(389);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 's') ADVANCE(649);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 647:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(615);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(526);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 648:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 's') ADVANCE(651);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(534);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 649:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(530);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(360);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 650:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(538);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(438);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 651:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(350);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(411);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 652:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(438);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(434);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 653:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(404);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(374);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 654:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(434);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(282);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 655:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(365);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(432);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 656:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(274);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(386);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 657:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(432);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 't') ADVANCE(665);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 658:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(378);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'u') ADVANCE(635);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 659:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 't') ADVANCE(666);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'u') ADVANCE(602);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(694);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 660:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'u') ADVANCE(637);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'u') ADVANCE(621);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(709);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 661:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'u') ADVANCE(606);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(695);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'u') ADVANCE(630);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 662:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'u') ADVANCE(610);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'u') ADVANCE(607);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 663:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'u') ADVANCE(632);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'x') ADVANCE(648);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 664:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'x') ADVANCE(650);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'y') ADVANCE(537);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(685);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 665:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'y') ADVANCE(541);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(686);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'y') ADVANCE(383);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 666:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'y') ADVANCE(374);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'y') ADVANCE(615);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 667:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'y') ADVANCE(618);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(705);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 668:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'A' ||
           lookahead == 'a') ADVANCE(706);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 669:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(707);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(671);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 670:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(672);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(683);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 671:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(684);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'e') ADVANCE(482);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 672:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(486);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'e') ADVANCE(703);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 673:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(704);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'e') ADVANCE(670);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 674:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(671);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'e') ADVANCE(684);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 675:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(685);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'e') ADVANCE(674);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 676:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(675);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'e') ADVANCE(707);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 677:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(708);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'H' ||
+          lookahead == 'h') ADVANCE(689);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 678:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'H' ||
-          lookahead == 'h') ADVANCE(690);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'h') ADVANCE(691);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 679:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'H' ||
-          lookahead == 'h') ADVANCE(692);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(694);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 680:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(695);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'i') ADVANCE(685);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 681:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(686);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'i') ADVANCE(696);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 682:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(697);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'i') ADVANCE(686);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 683:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(687);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(687);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 684:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(688);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'k') ADVANCE(690);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 685:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(691);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(714);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 686:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(715);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'l') ADVANCE(488);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 687:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(492);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'l') ADVANCE(716);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 688:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
           lookahead == 'l') ADVANCE(717);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 689:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
           lookahead == 'l') ADVANCE(718);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 690:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
           lookahead == 'l') ADVANCE(719);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 691:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
           lookahead == 'l') ADVANCE(720);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 692:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'L' ||
           lookahead == 'l') ADVANCE(721);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 693:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(722);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(485);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 694:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(489);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'm') ADVANCE(702);
+      if (lookahead == 'W' ||
+          lookahead == 'w') ADVANCE(675);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 695:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(703);
-      if (lookahead == 'W' ||
-          lookahead == 'w') ADVANCE(676);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(709);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 696:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(710);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'n') ADVANCE(669);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 697:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(670);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'n') ADVANCE(708);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 698:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(709);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'n') ADVANCE(711);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 699:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(712);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(491);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 700:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(495);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'o') ADVANCE(693);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 701:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(694);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'o') ADVANCE(697);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 702:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'O' ||
           lookahead == 'o') ADVANCE(698);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 703:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(699);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(715);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 704:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(716);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'r') ADVANCE(700);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 705:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(701);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'r') ADVANCE(710);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 706:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(711);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'r') ADVANCE(688);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 707:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(689);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'r') ADVANCE(692);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 708:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(693);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(677);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 709:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(678);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 't') ADVANCE(682);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 710:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(683);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 't') ADVANCE(676);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 711:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(677);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 't') ADVANCE(678);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 712:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(679);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'U' ||
+          lookahead == 'u') ADVANCE(667);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 713:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'U' ||
-          lookahead == 'u') ADVANCE(668);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'V' ||
+          lookahead == 'v') ADVANCE(672);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 714:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'V' ||
-          lookahead == 'v') ADVANCE(673);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(468);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 715:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(472);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'y') ADVANCE(574);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 716:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(578);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'y') ADVANCE(470);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 717:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(474);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'y') ADVANCE(480);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 718:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(484);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'y') ADVANCE(474);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 719:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(478);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'y') ADVANCE(472);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 720:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
           lookahead == 'y') ADVANCE(476);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 721:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
+      if (lookahead == '\n') ADVANCE(393);
       if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(480);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+          lookahead == 'y') ADVANCE(478);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 722:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(482);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (lookahead == '\n') ADVANCE(393);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(722);
       END_STATE();
     case 723:
       ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == '\n') ADVANCE(383);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_2, 430, lookahead)) ADVANCE(723);
+      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(723);
       END_STATE();
     case 724:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'a') ADVANCE(740);
-      if (lookahead == 'e') ADVANCE(753);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 725:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'a') ADVANCE(752);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 726:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'a') ADVANCE(754);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 727:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'c') ADVANCE(730);
-      if (lookahead == 'l') ADVANCE(741);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 728:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'c') ADVANCE(743);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 729:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'c') ADVANCE(744);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 730:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'c') ADVANCE(751);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 731:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'd') ADVANCE(345);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 732:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'd') ADVANCE(742);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 733:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'd') ADVANCE(736);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 734:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'e') ADVANCE(739);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 735:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'e') ADVANCE(725);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 736:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'e') ADVANCE(386);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 737:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'e') ADVANCE(756);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 738:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'e') ADVANCE(749);
-      if (lookahead == 'o') ADVANCE(732);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 739:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'f') ADVANCE(395);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 740:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'g') ADVANCE(381);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 741:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'i') ADVANCE(726);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 742:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'i') ADVANCE(759);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 743:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'k') ADVANCE(737);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 744:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'l') ADVANCE(762);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 745:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'm') ADVANCE(738);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 746:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'm') ADVANCE(745);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 747:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'n') ADVANCE(731);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 748:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'n') ADVANCE(757);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 749:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'n') ADVANCE(758);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 750:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'o') ADVANCE(746);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 751:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'o') ADVANCE(760);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 752:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'r') ADVANCE(399);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 753:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 's') ADVANCE(755);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 754:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 's') ADVANCE(390);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 755:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 't') ADVANCE(351);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 756:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 't') ADVANCE(405);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 757:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 't') ADVANCE(366);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 758:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 't') ADVANCE(275);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 759:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 't') ADVANCE(763);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 760:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'u') ADVANCE(748);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 761:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'u') ADVANCE(728);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 762:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'u') ADVANCE(733);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 763:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (lookahead == 'y') ADVANCE(375);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 764:
-      ACCEPT_TOKEN(aux_sym_commodity_token1);
-      if (set_contains(aux_sym_tag_directive_token1_character_set_1, 429, lookahead)) ADVANCE(764);
-      END_STATE();
-    case 765:
       ACCEPT_TOKEN(aux_sym_commodity_token2);
       END_STATE();
-    case 766:
+    case 725:
       ACCEPT_TOKEN(aux_sym_commodity_token3);
       END_STATE();
-    case 767:
+    case 726:
       ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(770);
+      if (lookahead == '{') ADVANCE(729);
       END_STATE();
-    case 768:
+    case 727:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 769:
+    case 728:
       ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead == '}') ADVANCE(771);
+      if (lookahead == '}') ADVANCE(730);
       END_STATE();
-    case 770:
+    case 729:
       ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
       END_STATE();
-    case 771:
+    case 730:
       ACCEPT_TOKEN(anon_sym_RBRACE_RBRACE);
       END_STATE();
-    case 772:
+    case 731:
       ACCEPT_TOKEN(anon_sym_AT);
-      if (lookahead == '@') ADVANCE(773);
+      if (lookahead == '@') ADVANCE(732);
       END_STATE();
-    case 773:
+    case 732:
       ACCEPT_TOKEN(anon_sym_AT_AT);
       END_STATE();
-    case 774:
+    case 733:
       ACCEPT_TOKEN(anon_sym_SPACE);
       END_STATE();
-    case 775:
+    case 734:
       ACCEPT_TOKEN(anon_sym_SPACE);
-      if (lookahead == '\n') ADVANCE(370);
-      if (lookahead != 0) ADVANCE(55);
+      if (lookahead == '\n') ADVANCE(378);
+      if (lookahead != 0) ADVANCE(61);
       END_STATE();
-    case 776:
-      ACCEPT_TOKEN(anon_sym_SPACE);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
-      END_STATE();
-    case 777:
+    case 735:
       ACCEPT_TOKEN(anon_sym_SPACE);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(363);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
-    case 778:
+    case 736:
       ACCEPT_TOKEN(anon_sym_SPACE);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(566);
+          lookahead != '\n') ADVANCE(372);
       END_STATE();
-    case 779:
+    case 737:
       ACCEPT_TOKEN(anon_sym_SPACE);
       if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(392);
+          lookahead != '\n') ADVANCE(562);
       END_STATE();
-    case 780:
+    case 738:
+      ACCEPT_TOKEN(anon_sym_SPACE);
+      if (lookahead != 0 &&
+          lookahead != '=') ADVANCE(401);
+      END_STATE();
+    case 739:
       ACCEPT_TOKEN(anon_sym_TAB);
       END_STATE();
-    case 781:
+    case 740:
       ACCEPT_TOKEN(anon_sym_TAB);
-      if (lookahead == '\n') ADVANCE(370);
-      if (lookahead != 0) ADVANCE(55);
+      if (lookahead == '\n') ADVANCE(378);
+      if (lookahead != 0) ADVANCE(61);
       END_STATE();
-    case 782:
+    case 741:
       ACCEPT_TOKEN(anon_sym_TAB);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(573);
+          lookahead != ' ') ADVANCE(569);
       END_STATE();
-    case 783:
+    case 742:
       ACCEPT_TOKEN(anon_sym_TAB);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(339);
+          lookahead != '\n') ADVANCE(350);
       END_STATE();
-    case 784:
+    case 743:
       ACCEPT_TOKEN(anon_sym_TAB);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(363);
+          lookahead != '\n') ADVANCE(372);
       END_STATE();
-    case 785:
+    case 744:
       ACCEPT_TOKEN(anon_sym_TAB);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(566);
+          lookahead != '\n') ADVANCE(562);
       END_STATE();
-    case 786:
+    case 745:
       ACCEPT_TOKEN(anon_sym_TAB);
       if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(392);
+          lookahead != '=') ADVANCE(401);
       END_STATE();
-    case 787:
+    case 746:
       ACCEPT_TOKEN(anon_sym_);
       END_STATE();
-    case 788:
+    case 747:
       ACCEPT_TOKEN(anon_sym_TAB2);
       END_STATE();
-    case 789:
+    case 748:
       ACCEPT_TOKEN(anon_sym_TAB3);
       END_STATE();
-    case 790:
+    case 749:
       ACCEPT_TOKEN(anon_sym_TAB_TAB);
       END_STATE();
     default:
@@ -6070,141 +5872,141 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 269},
-  [2] = {.lex_state = 269},
-  [3] = {.lex_state = 269},
-  [4] = {.lex_state = 269},
-  [5] = {.lex_state = 269},
-  [6] = {.lex_state = 269},
-  [7] = {.lex_state = 269},
-  [8] = {.lex_state = 269},
-  [9] = {.lex_state = 269},
+  [1] = {.lex_state = 277},
+  [2] = {.lex_state = 277},
+  [3] = {.lex_state = 277},
+  [4] = {.lex_state = 277},
+  [5] = {.lex_state = 277},
+  [6] = {.lex_state = 277},
+  [7] = {.lex_state = 277},
+  [8] = {.lex_state = 277},
+  [9] = {.lex_state = 277},
   [10] = {.lex_state = 5},
-  [11] = {.lex_state = 268},
-  [12] = {.lex_state = 268},
-  [13] = {.lex_state = 268},
-  [14] = {.lex_state = 268},
-  [15] = {.lex_state = 269},
-  [16] = {.lex_state = 269},
-  [17] = {.lex_state = 269},
-  [18] = {.lex_state = 268},
-  [19] = {.lex_state = 269},
-  [20] = {.lex_state = 269},
-  [21] = {.lex_state = 269},
-  [22] = {.lex_state = 269},
-  [23] = {.lex_state = 269},
-  [24] = {.lex_state = 269},
-  [25] = {.lex_state = 269},
-  [26] = {.lex_state = 269},
-  [27] = {.lex_state = 269},
-  [28] = {.lex_state = 268},
-  [29] = {.lex_state = 269},
-  [30] = {.lex_state = 268},
-  [31] = {.lex_state = 269},
-  [32] = {.lex_state = 269},
-  [33] = {.lex_state = 269},
-  [34] = {.lex_state = 269},
-  [35] = {.lex_state = 5},
-  [36] = {.lex_state = 269},
-  [37] = {.lex_state = 269},
-  [38] = {.lex_state = 269},
-  [39] = {.lex_state = 269},
-  [40] = {.lex_state = 269},
-  [41] = {.lex_state = 269},
-  [42] = {.lex_state = 269},
-  [43] = {.lex_state = 269},
-  [44] = {.lex_state = 269},
-  [45] = {.lex_state = 269},
-  [46] = {.lex_state = 269},
-  [47] = {.lex_state = 269},
-  [48] = {.lex_state = 269},
-  [49] = {.lex_state = 269},
-  [50] = {.lex_state = 269},
-  [51] = {.lex_state = 269},
-  [52] = {.lex_state = 269},
-  [53] = {.lex_state = 269},
-  [54] = {.lex_state = 269},
-  [55] = {.lex_state = 269},
-  [56] = {.lex_state = 269},
-  [57] = {.lex_state = 269},
-  [58] = {.lex_state = 269},
-  [59] = {.lex_state = 269},
-  [60] = {.lex_state = 269},
-  [61] = {.lex_state = 269},
-  [62] = {.lex_state = 269},
-  [63] = {.lex_state = 269},
-  [64] = {.lex_state = 269},
-  [65] = {.lex_state = 269},
-  [66] = {.lex_state = 269},
-  [67] = {.lex_state = 269},
-  [68] = {.lex_state = 340},
-  [69] = {.lex_state = 340},
-  [70] = {.lex_state = 340},
-  [71] = {.lex_state = 340},
-  [72] = {.lex_state = 340},
-  [73] = {.lex_state = 340},
-  [74] = {.lex_state = 340},
-  [75] = {.lex_state = 340},
-  [76] = {.lex_state = 269},
-  [77] = {.lex_state = 269},
-  [78] = {.lex_state = 269},
-  [79] = {.lex_state = 269},
-  [80] = {.lex_state = 269},
-  [81] = {.lex_state = 269},
-  [82] = {.lex_state = 269},
-  [83] = {.lex_state = 269},
-  [84] = {.lex_state = 269},
-  [85] = {.lex_state = 269},
-  [86] = {.lex_state = 269},
-  [87] = {.lex_state = 269},
-  [88] = {.lex_state = 269},
-  [89] = {.lex_state = 269},
-  [90] = {.lex_state = 269},
-  [91] = {.lex_state = 269},
+  [11] = {.lex_state = 277},
+  [12] = {.lex_state = 277},
+  [13] = {.lex_state = 277},
+  [14] = {.lex_state = 277},
+  [15] = {.lex_state = 277},
+  [16] = {.lex_state = 277},
+  [17] = {.lex_state = 277},
+  [18] = {.lex_state = 277},
+  [19] = {.lex_state = 277},
+  [20] = {.lex_state = 277},
+  [21] = {.lex_state = 277},
+  [22] = {.lex_state = 277},
+  [23] = {.lex_state = 277},
+  [24] = {.lex_state = 277},
+  [25] = {.lex_state = 277},
+  [26] = {.lex_state = 277},
+  [27] = {.lex_state = 277},
+  [28] = {.lex_state = 277},
+  [29] = {.lex_state = 277},
+  [30] = {.lex_state = 277},
+  [31] = {.lex_state = 277},
+  [32] = {.lex_state = 277},
+  [33] = {.lex_state = 277},
+  [34] = {.lex_state = 277},
+  [35] = {.lex_state = 277},
+  [36] = {.lex_state = 277},
+  [37] = {.lex_state = 277},
+  [38] = {.lex_state = 277},
+  [39] = {.lex_state = 277},
+  [40] = {.lex_state = 277},
+  [41] = {.lex_state = 277},
+  [42] = {.lex_state = 277},
+  [43] = {.lex_state = 277},
+  [44] = {.lex_state = 277},
+  [45] = {.lex_state = 277},
+  [46] = {.lex_state = 277},
+  [47] = {.lex_state = 277},
+  [48] = {.lex_state = 277},
+  [49] = {.lex_state = 277},
+  [50] = {.lex_state = 277},
+  [51] = {.lex_state = 277},
+  [52] = {.lex_state = 277},
+  [53] = {.lex_state = 277},
+  [54] = {.lex_state = 277},
+  [55] = {.lex_state = 277},
+  [56] = {.lex_state = 277},
+  [57] = {.lex_state = 277},
+  [58] = {.lex_state = 277},
+  [59] = {.lex_state = 351},
+  [60] = {.lex_state = 351},
+  [61] = {.lex_state = 351},
+  [62] = {.lex_state = 351},
+  [63] = {.lex_state = 351},
+  [64] = {.lex_state = 351},
+  [65] = {.lex_state = 5},
+  [66] = {.lex_state = 351},
+  [67] = {.lex_state = 351},
+  [68] = {.lex_state = 277},
+  [69] = {.lex_state = 277},
+  [70] = {.lex_state = 277},
+  [71] = {.lex_state = 277},
+  [72] = {.lex_state = 277},
+  [73] = {.lex_state = 277},
+  [74] = {.lex_state = 277},
+  [75] = {.lex_state = 277},
+  [76] = {.lex_state = 277},
+  [77] = {.lex_state = 277},
+  [78] = {.lex_state = 277},
+  [79] = {.lex_state = 277},
+  [80] = {.lex_state = 277},
+  [81] = {.lex_state = 277},
+  [82] = {.lex_state = 277},
+  [83] = {.lex_state = 277},
+  [84] = {.lex_state = 1},
+  [85] = {.lex_state = 1},
+  [86] = {.lex_state = 1},
+  [87] = {.lex_state = 1},
+  [88] = {.lex_state = 1},
+  [89] = {.lex_state = 1},
+  [90] = {.lex_state = 6},
+  [91] = {.lex_state = 2},
   [92] = {.lex_state = 1},
   [93] = {.lex_state = 1},
   [94] = {.lex_state = 1},
   [95] = {.lex_state = 1},
   [96] = {.lex_state = 1},
   [97] = {.lex_state = 1},
-  [98] = {.lex_state = 2},
-  [99] = {.lex_state = 6},
-  [100] = {.lex_state = 1},
+  [98] = {.lex_state = 0},
+  [99] = {.lex_state = 1},
+  [100] = {.lex_state = 0},
   [101] = {.lex_state = 1},
-  [102] = {.lex_state = 1},
-  [103] = {.lex_state = 1},
-  [104] = {.lex_state = 1},
-  [105] = {.lex_state = 1},
-  [106] = {.lex_state = 1},
-  [107] = {.lex_state = 1},
+  [102] = {.lex_state = 0},
+  [103] = {.lex_state = 0},
+  [104] = {.lex_state = 9},
+  [105] = {.lex_state = 5},
+  [106] = {.lex_state = 9},
+  [107] = {.lex_state = 0},
   [108] = {.lex_state = 0},
   [109] = {.lex_state = 0},
   [110] = {.lex_state = 0},
-  [111] = {.lex_state = 0},
-  [112] = {.lex_state = 9},
-  [113] = {.lex_state = 0},
-  [114] = {.lex_state = 0},
-  [115] = {.lex_state = 0},
-  [116] = {.lex_state = 5},
-  [117] = {.lex_state = 0},
-  [118] = {.lex_state = 9},
-  [119] = {.lex_state = 9},
+  [111] = {.lex_state = 9},
+  [112] = {.lex_state = 1},
+  [113] = {.lex_state = 1},
+  [114] = {.lex_state = 1},
+  [115] = {.lex_state = 1},
+  [116] = {.lex_state = 1},
+  [117] = {.lex_state = 1},
+  [118] = {.lex_state = 1},
+  [119] = {.lex_state = 1},
   [120] = {.lex_state = 1},
-  [121] = {.lex_state = 11},
+  [121] = {.lex_state = 1},
   [122] = {.lex_state = 1},
   [123] = {.lex_state = 1},
   [124] = {.lex_state = 1},
-  [125] = {.lex_state = 1},
+  [125] = {.lex_state = 11},
   [126] = {.lex_state = 1},
-  [127] = {.lex_state = 1},
-  [128] = {.lex_state = 1},
-  [129] = {.lex_state = 1},
-  [130] = {.lex_state = 1},
-  [131] = {.lex_state = 1},
-  [132] = {.lex_state = 1},
-  [133] = {.lex_state = 1},
-  [134] = {.lex_state = 1},
-  [135] = {.lex_state = 5},
+  [127] = {.lex_state = 0},
+  [128] = {.lex_state = 0},
+  [129] = {.lex_state = 5},
+  [130] = {.lex_state = 0},
+  [131] = {.lex_state = 0},
+  [132] = {.lex_state = 0},
+  [133] = {.lex_state = 0},
+  [134] = {.lex_state = 0},
+  [135] = {.lex_state = 0},
   [136] = {.lex_state = 0},
   [137] = {.lex_state = 0},
   [138] = {.lex_state = 0},
@@ -6213,232 +6015,232 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [141] = {.lex_state = 0},
   [142] = {.lex_state = 0},
   [143] = {.lex_state = 0},
-  [144] = {.lex_state = 0},
-  [145] = {.lex_state = 0},
-  [146] = {.lex_state = 0},
-  [147] = {.lex_state = 0},
-  [148] = {.lex_state = 0},
-  [149] = {.lex_state = 0},
-  [150] = {.lex_state = 0},
-  [151] = {.lex_state = 0},
-  [152] = {.lex_state = 9},
-  [153] = {.lex_state = 1},
-  [154] = {.lex_state = 5},
-  [155] = {.lex_state = 11},
-  [156] = {.lex_state = 8},
-  [157] = {.lex_state = 8},
-  [158] = {.lex_state = 1},
-  [159] = {.lex_state = 1},
-  [160] = {.lex_state = 4},
-  [161] = {.lex_state = 277},
-  [162] = {.lex_state = 278},
+  [144] = {.lex_state = 1},
+  [145] = {.lex_state = 9},
+  [146] = {.lex_state = 8},
+  [147] = {.lex_state = 1},
+  [148] = {.lex_state = 5},
+  [149] = {.lex_state = 8},
+  [150] = {.lex_state = 4},
+  [151] = {.lex_state = 11},
+  [152] = {.lex_state = 284},
+  [153] = {.lex_state = 3},
+  [154] = {.lex_state = 277},
+  [155] = {.lex_state = 277},
+  [156] = {.lex_state = 285},
+  [157] = {.lex_state = 284},
+  [158] = {.lex_state = 284},
+  [159] = {.lex_state = 0},
+  [160] = {.lex_state = 1},
+  [161] = {.lex_state = 284},
+  [162] = {.lex_state = 285},
   [163] = {.lex_state = 0},
-  [164] = {.lex_state = 277},
-  [165] = {.lex_state = 3},
-  [166] = {.lex_state = 277},
-  [167] = {.lex_state = 0},
-  [168] = {.lex_state = 1},
-  [169] = {.lex_state = 278},
-  [170] = {.lex_state = 278},
+  [164] = {.lex_state = 1},
+  [165] = {.lex_state = 277},
+  [166] = {.lex_state = 0},
+  [167] = {.lex_state = 1},
+  [168] = {.lex_state = 277},
+  [169] = {.lex_state = 0},
+  [170] = {.lex_state = 277},
   [171] = {.lex_state = 0},
-  [172] = {.lex_state = 269},
-  [173] = {.lex_state = 0},
-  [174] = {.lex_state = 1},
-  [175] = {.lex_state = 269},
-  [176] = {.lex_state = 0},
-  [177] = {.lex_state = 278},
-  [178] = {.lex_state = 269},
-  [179] = {.lex_state = 0},
-  [180] = {.lex_state = 1},
-  [181] = {.lex_state = 0},
-  [182] = {.lex_state = 269},
-  [183] = {.lex_state = 269},
+  [172] = {.lex_state = 0},
+  [173] = {.lex_state = 284},
+  [174] = {.lex_state = 285},
+  [175] = {.lex_state = 285},
+  [176] = {.lex_state = 4},
+  [177] = {.lex_state = 1},
+  [178] = {.lex_state = 0},
+  [179] = {.lex_state = 285},
+  [180] = {.lex_state = 0},
+  [181] = {.lex_state = 12},
+  [182] = {.lex_state = 1},
+  [183] = {.lex_state = 12},
   [184] = {.lex_state = 1},
-  [185] = {.lex_state = 278},
+  [185] = {.lex_state = 3},
   [186] = {.lex_state = 0},
-  [187] = {.lex_state = 277},
-  [188] = {.lex_state = 277},
+  [187] = {.lex_state = 12},
+  [188] = {.lex_state = 12},
   [189] = {.lex_state = 0},
-  [190] = {.lex_state = 12},
-  [191] = {.lex_state = 5},
-  [192] = {.lex_state = 1},
+  [190] = {.lex_state = 0},
+  [191] = {.lex_state = 1},
+  [192] = {.lex_state = 0},
   [193] = {.lex_state = 0},
   [194] = {.lex_state = 0},
-  [195] = {.lex_state = 0},
-  [196] = {.lex_state = 1},
+  [195] = {.lex_state = 1},
+  [196] = {.lex_state = 12},
   [197] = {.lex_state = 0},
-  [198] = {.lex_state = 0},
-  [199] = {.lex_state = 12},
+  [198] = {.lex_state = 12},
+  [199] = {.lex_state = 0},
   [200] = {.lex_state = 0},
-  [201] = {.lex_state = 12},
+  [201] = {.lex_state = 7},
   [202] = {.lex_state = 7},
-  [203] = {.lex_state = 0},
-  [204] = {.lex_state = 5},
-  [205] = {.lex_state = 1},
-  [206] = {.lex_state = 12},
+  [203] = {.lex_state = 5},
+  [204] = {.lex_state = 12},
+  [205] = {.lex_state = 5},
+  [206] = {.lex_state = 0},
   [207] = {.lex_state = 12},
-  [208] = {.lex_state = 1},
-  [209] = {.lex_state = 5},
+  [208] = {.lex_state = 12},
+  [209] = {.lex_state = 0},
   [210] = {.lex_state = 12},
-  [211] = {.lex_state = 0},
-  [212] = {.lex_state = 0},
-  [213] = {.lex_state = 12},
-  [214] = {.lex_state = 3},
-  [215] = {.lex_state = 12},
-  [216] = {.lex_state = 4},
-  [217] = {.lex_state = 12},
-  [218] = {.lex_state = 12},
-  [219] = {.lex_state = 1},
-  [220] = {.lex_state = 5},
-  [221] = {.lex_state = 12},
+  [211] = {.lex_state = 1},
+  [212] = {.lex_state = 12},
+  [213] = {.lex_state = 0},
+  [214] = {.lex_state = 277},
+  [215] = {.lex_state = 284},
+  [216] = {.lex_state = 0},
+  [217] = {.lex_state = 284},
+  [218] = {.lex_state = 0},
+  [219] = {.lex_state = 0},
+  [220] = {.lex_state = 20},
+  [221] = {.lex_state = 0},
   [222] = {.lex_state = 0},
-  [223] = {.lex_state = 1},
-  [224] = {.lex_state = 7},
+  [223] = {.lex_state = 285},
+  [224] = {.lex_state = 20},
   [225] = {.lex_state = 0},
-  [226] = {.lex_state = 20},
-  [227] = {.lex_state = 0},
-  [228] = {.lex_state = 0},
-  [229] = {.lex_state = 0},
+  [226] = {.lex_state = 7},
+  [227] = {.lex_state = 285},
+  [228] = {.lex_state = 4},
+  [229] = {.lex_state = 12},
   [230] = {.lex_state = 0},
   [231] = {.lex_state = 0},
-  [232] = {.lex_state = 3},
-  [233] = {.lex_state = 277},
-  [234] = {.lex_state = 269},
+  [232] = {.lex_state = 0},
+  [233] = {.lex_state = 0},
+  [234] = {.lex_state = 277},
   [235] = {.lex_state = 0},
   [236] = {.lex_state = 0},
   [237] = {.lex_state = 0},
   [238] = {.lex_state = 0},
-  [239] = {.lex_state = 4},
-  [240] = {.lex_state = 277},
+  [239] = {.lex_state = 3},
+  [240] = {.lex_state = 13},
   [241] = {.lex_state = 0},
   [242] = {.lex_state = 0},
-  [243] = {.lex_state = 0},
-  [244] = {.lex_state = 0},
-  [245] = {.lex_state = 0},
-  [246] = {.lex_state = 20},
-  [247] = {.lex_state = 278},
-  [248] = {.lex_state = 7},
-  [249] = {.lex_state = 278},
-  [250] = {.lex_state = 12},
-  [251] = {.lex_state = 0},
+  [243] = {.lex_state = 13},
+  [244] = {.lex_state = 5},
+  [245] = {.lex_state = 13},
+  [246] = {.lex_state = 277},
+  [247] = {.lex_state = 0},
+  [248] = {.lex_state = 13},
+  [249] = {.lex_state = 0},
+  [250] = {.lex_state = 0},
+  [251] = {.lex_state = 5},
   [252] = {.lex_state = 18},
-  [253] = {.lex_state = 5},
+  [253] = {.lex_state = 13},
   [254] = {.lex_state = 0},
   [255] = {.lex_state = 0},
   [256] = {.lex_state = 0},
   [257] = {.lex_state = 0},
-  [258] = {.lex_state = 13},
+  [258] = {.lex_state = 0},
   [259] = {.lex_state = 13},
-  [260] = {.lex_state = 0},
+  [260] = {.lex_state = 18},
   [261] = {.lex_state = 20},
   [262] = {.lex_state = 0},
-  [263] = {.lex_state = 269},
+  [263] = {.lex_state = 0},
   [264] = {.lex_state = 0},
-  [265] = {.lex_state = 2},
-  [266] = {.lex_state = 13},
-  [267] = {.lex_state = 0},
+  [265] = {.lex_state = 0},
+  [266] = {.lex_state = 0},
+  [267] = {.lex_state = 13},
   [268] = {.lex_state = 0},
   [269] = {.lex_state = 0},
   [270] = {.lex_state = 0},
   [271] = {.lex_state = 0},
   [272] = {.lex_state = 0},
-  [273] = {.lex_state = 13},
+  [273] = {.lex_state = 5},
   [274] = {.lex_state = 0},
-  [275] = {.lex_state = 13},
+  [275] = {.lex_state = 5},
   [276] = {.lex_state = 0},
-  [277] = {.lex_state = 13},
-  [278] = {.lex_state = 0},
-  [279] = {.lex_state = 5},
+  [277] = {.lex_state = 0},
+  [278] = {.lex_state = 12},
+  [279] = {.lex_state = 13},
   [280] = {.lex_state = 0},
-  [281] = {.lex_state = 13},
-  [282] = {.lex_state = 0},
-  [283] = {.lex_state = 0},
-  [284] = {.lex_state = 12},
-  [285] = {.lex_state = 18},
-  [286] = {.lex_state = 5},
-  [287] = {.lex_state = 0},
-  [288] = {.lex_state = 13},
-  [289] = {.lex_state = 5},
-  [290] = {.lex_state = 5},
-  [291] = {.lex_state = 5},
-  [292] = {.lex_state = 5},
-  [293] = {.lex_state = 0},
-  [294] = {.lex_state = 5},
+  [281] = {.lex_state = 0},
+  [282] = {.lex_state = 2},
+  [283] = {.lex_state = 13},
+  [284] = {.lex_state = 0},
+  [285] = {.lex_state = 0},
+  [286] = {.lex_state = 16},
+  [287] = {.lex_state = 18},
+  [288] = {.lex_state = 0},
+  [289] = {.lex_state = 0},
+  [290] = {.lex_state = 4},
+  [291] = {.lex_state = 4},
+  [292] = {.lex_state = 0},
+  [293] = {.lex_state = 16},
+  [294] = {.lex_state = 8},
   [295] = {.lex_state = 0},
-  [296] = {.lex_state = 13},
+  [296] = {.lex_state = 19},
   [297] = {.lex_state = 0},
-  [298] = {.lex_state = 0},
-  [299] = {.lex_state = 0},
-  [300] = {.lex_state = 269},
-  [301] = {.lex_state = 4},
+  [298] = {.lex_state = 277},
+  [299] = {.lex_state = 277},
+  [300] = {.lex_state = 5},
+  [301] = {.lex_state = 5},
   [302] = {.lex_state = 0},
-  [303] = {.lex_state = 5},
-  [304] = {.lex_state = 269},
-  [305] = {.lex_state = 0},
-  [306] = {.lex_state = 0},
-  [307] = {.lex_state = 3},
-  [308] = {.lex_state = 16},
-  [309] = {.lex_state = 18},
-  [310] = {.lex_state = 4},
-  [311] = {.lex_state = 4},
-  [312] = {.lex_state = 0},
-  [313] = {.lex_state = 8},
+  [303] = {.lex_state = 4},
+  [304] = {.lex_state = 16},
+  [305] = {.lex_state = 4},
+  [306] = {.lex_state = 16},
+  [307] = {.lex_state = 16},
+  [308] = {.lex_state = 8},
+  [309] = {.lex_state = 4},
+  [310] = {.lex_state = 8},
+  [311] = {.lex_state = 277},
+  [312] = {.lex_state = 5},
+  [313] = {.lex_state = 16},
   [314] = {.lex_state = 8},
   [315] = {.lex_state = 8},
-  [316] = {.lex_state = 8},
-  [317] = {.lex_state = 0},
+  [316] = {.lex_state = 4},
+  [317] = {.lex_state = 4},
   [318] = {.lex_state = 8},
-  [319] = {.lex_state = 5},
-  [320] = {.lex_state = 5},
-  [321] = {.lex_state = 269},
-  [322] = {.lex_state = 269},
-  [323] = {.lex_state = 17},
-  [324] = {.lex_state = 17},
-  [325] = {.lex_state = 4},
-  [326] = {.lex_state = 8},
-  [327] = {.lex_state = 5},
-  [328] = {.lex_state = 0},
-  [329] = {.lex_state = 4},
-  [330] = {.lex_state = 4},
-  [331] = {.lex_state = 0},
-  [332] = {.lex_state = 4},
-  [333] = {.lex_state = 8},
-  [334] = {.lex_state = 8},
-  [335] = {.lex_state = 279},
-  [336] = {.lex_state = 4},
-  [337] = {.lex_state = 19},
-  [338] = {.lex_state = 279},
+  [319] = {.lex_state = 3},
+  [320] = {.lex_state = 4},
+  [321] = {.lex_state = 17},
+  [322] = {.lex_state = 277},
+  [323] = {.lex_state = 4},
+  [324] = {.lex_state = 286},
+  [325] = {.lex_state = 0},
+  [326] = {.lex_state = 0},
+  [327] = {.lex_state = 277},
+  [328] = {.lex_state = 286},
+  [329] = {.lex_state = 19},
+  [330] = {.lex_state = 10},
+  [331] = {.lex_state = 5},
+  [332] = {.lex_state = 0},
+  [333] = {.lex_state = 4},
+  [334] = {.lex_state = 0},
+  [335] = {.lex_state = 10},
+  [336] = {.lex_state = 10},
+  [337] = {.lex_state = 286},
+  [338] = {.lex_state = 286},
   [339] = {.lex_state = 10},
-  [340] = {.lex_state = 0},
-  [341] = {.lex_state = 4},
-  [342] = {.lex_state = 269},
-  [343] = {.lex_state = 10},
-  [344] = {.lex_state = 10},
-  [345] = {.lex_state = 0},
-  [346] = {.lex_state = 17},
+  [340] = {.lex_state = 10},
+  [341] = {.lex_state = 10},
+  [342] = {.lex_state = 10},
+  [343] = {.lex_state = 0},
+  [344] = {.lex_state = 8},
+  [345] = {.lex_state = 8},
+  [346] = {.lex_state = 18},
   [347] = {.lex_state = 17},
-  [348] = {.lex_state = 10},
-  [349] = {.lex_state = 17},
-  [350] = {.lex_state = 10},
-  [351] = {.lex_state = 10},
-  [352] = {.lex_state = 10},
-  [353] = {.lex_state = 279},
+  [348] = {.lex_state = 0},
+  [349] = {.lex_state = 16},
+  [350] = {.lex_state = 286},
+  [351] = {.lex_state = 4},
+  [352] = {.lex_state = 21},
+  [353] = {.lex_state = 0},
   [354] = {.lex_state = 0},
-  [355] = {.lex_state = 18},
-  [356] = {.lex_state = 16},
-  [357] = {.lex_state = 279},
-  [358] = {.lex_state = 4},
-  [359] = {.lex_state = 19},
-  [360] = {.lex_state = 17},
+  [355] = {.lex_state = 0},
+  [356] = {.lex_state = 0},
+  [357] = {.lex_state = 0},
+  [358] = {.lex_state = 21},
+  [359] = {.lex_state = 21},
+  [360] = {.lex_state = 0},
   [361] = {.lex_state = 0},
   [362] = {.lex_state = 0},
-  [363] = {.lex_state = 279},
+  [363] = {.lex_state = 0},
   [364] = {.lex_state = 0},
   [365] = {.lex_state = 0},
   [366] = {.lex_state = 0},
-  [367] = {.lex_state = 21},
+  [367] = {.lex_state = 0},
   [368] = {.lex_state = 0},
-  [369] = {.lex_state = 21},
+  [369] = {.lex_state = 0},
   [370] = {.lex_state = 0},
   [371] = {.lex_state = 0},
   [372] = {.lex_state = 0},
@@ -6449,72 +6251,72 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [377] = {.lex_state = 0},
   [378] = {.lex_state = 0},
   [379] = {.lex_state = 0},
-  [380] = {.lex_state = 0},
+  [380] = {.lex_state = 21},
   [381] = {.lex_state = 0},
   [382] = {.lex_state = 0},
-  [383] = {.lex_state = 21},
+  [383] = {.lex_state = 0},
   [384] = {.lex_state = 0},
-  [385] = {.lex_state = 21},
+  [385] = {.lex_state = 0},
   [386] = {.lex_state = 0},
-  [387] = {.lex_state = 0},
-  [388] = {.lex_state = 21},
-  [389] = {.lex_state = 0},
-  [390] = {.lex_state = 0},
+  [387] = {.lex_state = 21},
+  [388] = {.lex_state = 0},
+  [389] = {.lex_state = 21},
+  [390] = {.lex_state = 21},
   [391] = {.lex_state = 0},
   [392] = {.lex_state = 0},
   [393] = {.lex_state = 0},
-  [394] = {.lex_state = 0},
+  [394] = {.lex_state = 276},
   [395] = {.lex_state = 0},
   [396] = {.lex_state = 0},
   [397] = {.lex_state = 0},
-  [398] = {.lex_state = 21},
+  [398] = {.lex_state = 5},
   [399] = {.lex_state = 0},
-  [400] = {.lex_state = 21},
-  [401] = {.lex_state = 0},
+  [400] = {.lex_state = 0},
+  [401] = {.lex_state = 5},
   [402] = {.lex_state = 0},
-  [403] = {.lex_state = 0},
+  [403] = {.lex_state = 5},
   [404] = {.lex_state = 0},
-  [405] = {.lex_state = 0},
-  [406] = {.lex_state = 267},
-  [407] = {.lex_state = 0},
+  [405] = {.lex_state = 5},
+  [406] = {.lex_state = 5},
+  [407] = {.lex_state = 5},
   [408] = {.lex_state = 0},
-  [409] = {.lex_state = 5},
-  [410] = {.lex_state = 5},
-  [411] = {.lex_state = 5},
-  [412] = {.lex_state = 5},
-  [413] = {.lex_state = 0},
+  [409] = {.lex_state = 0},
+  [410] = {.lex_state = 0},
+  [411] = {.lex_state = 274},
+  [412] = {.lex_state = 2},
+  [413] = {.lex_state = 275},
   [414] = {.lex_state = 0},
-  [415] = {.lex_state = 5},
-  [416] = {.lex_state = 5},
-  [417] = {.lex_state = 5},
-  [418] = {.lex_state = 5},
+  [415] = {.lex_state = 0},
+  [416] = {.lex_state = 0},
+  [417] = {.lex_state = 0},
+  [418] = {.lex_state = 0},
   [419] = {.lex_state = 0},
   [420] = {.lex_state = 0},
-  [421] = {.lex_state = 5},
-  [422] = {.lex_state = 5},
-  [423] = {.lex_state = 5},
+  [421] = {.lex_state = 0},
+  [422] = {.lex_state = 13},
+  [423] = {.lex_state = 0},
   [424] = {.lex_state = 0},
   [425] = {.lex_state = 0},
   [426] = {.lex_state = 0},
-  [427] = {.lex_state = 0},
+  [427] = {.lex_state = 276},
   [428] = {.lex_state = 0},
   [429] = {.lex_state = 0},
   [430] = {.lex_state = 0},
   [431] = {.lex_state = 0},
   [432] = {.lex_state = 0},
   [433] = {.lex_state = 0},
-  [434] = {.lex_state = 0},
+  [434] = {.lex_state = 274},
   [435] = {.lex_state = 0},
   [436] = {.lex_state = 0},
-  [437] = {.lex_state = 266},
+  [437] = {.lex_state = 0},
   [438] = {.lex_state = 0},
   [439] = {.lex_state = 0},
   [440] = {.lex_state = 0},
-  [441] = {.lex_state = 0},
-  [442] = {.lex_state = 2},
-  [443] = {.lex_state = 2},
+  [441] = {.lex_state = 2},
+  [442] = {.lex_state = 13},
+  [443] = {.lex_state = 0},
   [444] = {.lex_state = 0},
-  [445] = {.lex_state = 0},
+  [445] = {.lex_state = 13},
   [446] = {.lex_state = 0},
   [447] = {.lex_state = 0},
   [448] = {.lex_state = 0},
@@ -6523,17 +6325,17 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [451] = {.lex_state = 0},
   [452] = {.lex_state = 0},
   [453] = {.lex_state = 0},
-  [454] = {.lex_state = 13},
-  [455] = {.lex_state = 265},
+  [454] = {.lex_state = 0},
+  [455] = {.lex_state = 0},
   [456] = {.lex_state = 0},
   [457] = {.lex_state = 0},
-  [458] = {.lex_state = 0},
-  [459] = {.lex_state = 563},
+  [458] = {.lex_state = 2},
+  [459] = {.lex_state = 0},
   [460] = {.lex_state = 0},
   [461] = {.lex_state = 0},
-  [462] = {.lex_state = 13},
+  [462] = {.lex_state = 0},
   [463] = {.lex_state = 0},
-  [464] = {.lex_state = 265},
+  [464] = {.lex_state = 559},
   [465] = {.lex_state = 0},
   [466] = {.lex_state = 0},
   [467] = {.lex_state = 0},
@@ -6543,24 +6345,10 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [471] = {.lex_state = 0},
   [472] = {.lex_state = 0},
   [473] = {.lex_state = 0},
-  [474] = {.lex_state = 267},
-  [475] = {.lex_state = 2},
+  [474] = {.lex_state = 0},
+  [475] = {.lex_state = 0},
   [476] = {.lex_state = 0},
   [477] = {.lex_state = 0},
-  [478] = {.lex_state = 0},
-  [479] = {.lex_state = 0},
-  [480] = {.lex_state = 0},
-  [481] = {.lex_state = 0},
-  [482] = {.lex_state = 0},
-  [483] = {.lex_state = 0},
-  [484] = {.lex_state = 0},
-  [485] = {.lex_state = 0},
-  [486] = {.lex_state = 0},
-  [487] = {.lex_state = 0},
-  [488] = {.lex_state = 13},
-  [489] = {.lex_state = 0},
-  [490] = {.lex_state = 0},
-  [491] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -6580,6 +6368,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_payee] = ACTIONS(1),
     [anon_sym_commodity] = ACTIONS(1),
     [anon_sym_nomarket] = ACTIONS(1),
+    [anon_sym_uuid] = ACTIONS(1),
     [anon_sym_tag] = ACTIONS(1),
     [aux_sym_tag_directive_token1] = ACTIONS(1),
     [anon_sym_include] = ACTIONS(1),
@@ -6657,27 +6446,28 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_TAB] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(446),
+    [sym_source_file] = STATE(414),
     [sym_journal_item] = STATE(2),
-    [sym_block_comment] = STATE(86),
-    [sym_test] = STATE(86),
-    [sym_option] = STATE(85),
-    [sym_directive] = STATE(86),
-    [sym_account_directive] = STATE(85),
-    [sym_commodity_directive] = STATE(85),
-    [sym_tag_directive] = STATE(85),
-    [sym_word_directive] = STATE(430),
-    [sym_char_directive] = STATE(430),
-    [sym_check_in] = STATE(463),
-    [sym_check_out] = STATE(463),
-    [sym_xact] = STATE(86),
-    [sym_plain_xact] = STATE(78),
-    [sym_periodic_xact] = STATE(78),
-    [sym_automated_xact] = STATE(78),
-    [sym__xact_date] = STATE(230),
-    [sym_date] = STATE(231),
-    [sym__4d] = STATE(443),
-    [sym__single_date] = STATE(232),
+    [sym_block_comment] = STATE(76),
+    [sym_test] = STATE(76),
+    [sym_option] = STATE(68),
+    [sym_directive] = STATE(76),
+    [sym_account_directive] = STATE(68),
+    [sym_commodity_directive] = STATE(68),
+    [sym_payee_directive] = STATE(68),
+    [sym_tag_directive] = STATE(68),
+    [sym_word_directive] = STATE(462),
+    [sym_char_directive] = STATE(462),
+    [sym_check_in] = STATE(473),
+    [sym_check_out] = STATE(473),
+    [sym_xact] = STATE(76),
+    [sym_plain_xact] = STATE(77),
+    [sym_periodic_xact] = STATE(77),
+    [sym_automated_xact] = STATE(77),
+    [sym__xact_date] = STATE(237),
+    [sym_date] = STATE(233),
+    [sym__4d] = STATE(441),
+    [sym__single_date] = STATE(239),
     [aux_sym_source_file_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(3),
     [anon_sym_LF] = ACTIONS(5),
@@ -6689,31 +6479,32 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_DASH_DASH] = ACTIONS(17),
     [anon_sym_EQ] = ACTIONS(19),
     [anon_sym_account] = ACTIONS(21),
-    [anon_sym_commodity] = ACTIONS(23),
-    [anon_sym_tag] = ACTIONS(25),
-    [anon_sym_include] = ACTIONS(27),
-    [anon_sym_alias] = ACTIONS(29),
-    [anon_sym_def] = ACTIONS(31),
-    [anon_sym_year] = ACTIONS(33),
-    [aux_sym_word_directive_token2] = ACTIONS(35),
-    [anon_sym_bucket] = ACTIONS(37),
-    [anon_sym_A] = ACTIONS(39),
-    [anon_sym_Y] = ACTIONS(41),
-    [anon_sym_N] = ACTIONS(43),
-    [anon_sym_D] = ACTIONS(45),
-    [anon_sym_C] = ACTIONS(47),
-    [anon_sym_P] = ACTIONS(49),
-    [anon_sym_i] = ACTIONS(51),
-    [anon_sym_I] = ACTIONS(53),
-    [anon_sym_o] = ACTIONS(55),
-    [anon_sym_O] = ACTIONS(55),
-    [anon_sym_TILDE] = ACTIONS(57),
-    [sym__2d] = ACTIONS(59),
+    [anon_sym_payee] = ACTIONS(23),
+    [anon_sym_commodity] = ACTIONS(25),
+    [anon_sym_tag] = ACTIONS(27),
+    [anon_sym_include] = ACTIONS(29),
+    [anon_sym_alias] = ACTIONS(31),
+    [anon_sym_def] = ACTIONS(33),
+    [anon_sym_year] = ACTIONS(35),
+    [aux_sym_word_directive_token2] = ACTIONS(37),
+    [anon_sym_bucket] = ACTIONS(39),
+    [anon_sym_A] = ACTIONS(41),
+    [anon_sym_Y] = ACTIONS(43),
+    [anon_sym_N] = ACTIONS(45),
+    [anon_sym_D] = ACTIONS(47),
+    [anon_sym_C] = ACTIONS(49),
+    [anon_sym_P] = ACTIONS(51),
+    [anon_sym_i] = ACTIONS(53),
+    [anon_sym_I] = ACTIONS(55),
+    [anon_sym_o] = ACTIONS(57),
+    [anon_sym_O] = ACTIONS(57),
+    [anon_sym_TILDE] = ACTIONS(59),
+    [sym__2d] = ACTIONS(61),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 39,
+  [0] = 40,
     ACTIONS(7), 1,
       sym_comment,
     ACTIONS(9), 1,
@@ -6731,237 +6522,196 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(21), 1,
       anon_sym_account,
     ACTIONS(23), 1,
-      anon_sym_commodity,
+      anon_sym_payee,
     ACTIONS(25), 1,
-      anon_sym_tag,
+      anon_sym_commodity,
     ACTIONS(27), 1,
-      anon_sym_include,
+      anon_sym_tag,
     ACTIONS(29), 1,
-      anon_sym_alias,
+      anon_sym_include,
     ACTIONS(31), 1,
-      anon_sym_def,
+      anon_sym_alias,
     ACTIONS(33), 1,
-      anon_sym_year,
+      anon_sym_def,
     ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
+      anon_sym_year,
     ACTIONS(37), 1,
-      anon_sym_bucket,
+      aux_sym_word_directive_token2,
     ACTIONS(39), 1,
-      anon_sym_A,
+      anon_sym_bucket,
     ACTIONS(41), 1,
-      anon_sym_Y,
+      anon_sym_A,
     ACTIONS(43), 1,
-      anon_sym_N,
+      anon_sym_Y,
     ACTIONS(45), 1,
-      anon_sym_D,
+      anon_sym_N,
     ACTIONS(47), 1,
-      anon_sym_C,
+      anon_sym_D,
     ACTIONS(49), 1,
-      anon_sym_P,
+      anon_sym_C,
     ACTIONS(51), 1,
-      anon_sym_i,
+      anon_sym_P,
     ACTIONS(53), 1,
+      anon_sym_i,
+    ACTIONS(55), 1,
       anon_sym_I,
-    ACTIONS(57), 1,
-      anon_sym_TILDE,
     ACTIONS(59), 1,
-      sym__2d,
+      anon_sym_TILDE,
     ACTIONS(61), 1,
-      ts_builtin_sym_end,
+      sym__2d,
     ACTIONS(63), 1,
-      anon_sym_LF,
-    STATE(230), 1,
-      sym__xact_date,
-    STATE(231), 1,
-      sym_date,
-    STATE(232), 1,
-      sym__single_date,
-    STATE(443), 1,
-      sym__4d,
-    ACTIONS(55), 2,
-      anon_sym_o,
-      anon_sym_O,
-    STATE(3), 2,
-      sym_journal_item,
-      aux_sym_source_file_repeat1,
-    STATE(430), 2,
-      sym_word_directive,
-      sym_char_directive,
-    STATE(463), 2,
-      sym_check_in,
-      sym_check_out,
-    STATE(78), 3,
-      sym_plain_xact,
-      sym_periodic_xact,
-      sym_automated_xact,
-    STATE(85), 4,
-      sym_option,
-      sym_account_directive,
-      sym_commodity_directive,
-      sym_tag_directive,
-    STATE(86), 4,
-      sym_block_comment,
-      sym_test,
-      sym_directive,
-      sym_xact,
-  [130] = 39,
+      ts_builtin_sym_end,
     ACTIONS(65), 1,
-      ts_builtin_sym_end,
-    ACTIONS(67), 1,
       anon_sym_LF,
-    ACTIONS(70), 1,
-      sym_comment,
-    ACTIONS(73), 1,
-      anon_sym_comment,
-    ACTIONS(76), 1,
-      anon_sym_end,
-    ACTIONS(79), 1,
-      anon_sym_test,
-    ACTIONS(82), 1,
-      anon_sym_DASH,
-    ACTIONS(85), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(88), 1,
-      anon_sym_EQ,
-    ACTIONS(91), 1,
-      anon_sym_account,
-    ACTIONS(94), 1,
-      anon_sym_commodity,
-    ACTIONS(97), 1,
-      anon_sym_tag,
-    ACTIONS(100), 1,
-      anon_sym_include,
-    ACTIONS(103), 1,
-      anon_sym_alias,
-    ACTIONS(106), 1,
-      anon_sym_def,
-    ACTIONS(109), 1,
-      anon_sym_year,
-    ACTIONS(112), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(115), 1,
-      anon_sym_bucket,
-    ACTIONS(118), 1,
-      anon_sym_A,
-    ACTIONS(121), 1,
-      anon_sym_Y,
-    ACTIONS(124), 1,
-      anon_sym_N,
-    ACTIONS(127), 1,
-      anon_sym_D,
-    ACTIONS(130), 1,
-      anon_sym_C,
-    ACTIONS(133), 1,
-      anon_sym_P,
-    ACTIONS(136), 1,
-      anon_sym_i,
-    ACTIONS(139), 1,
-      anon_sym_I,
-    ACTIONS(145), 1,
-      anon_sym_TILDE,
-    ACTIONS(148), 1,
-      sym__2d,
-    STATE(230), 1,
-      sym__xact_date,
-    STATE(231), 1,
+    STATE(233), 1,
       sym_date,
-    STATE(232), 1,
+    STATE(237), 1,
+      sym__xact_date,
+    STATE(239), 1,
       sym__single_date,
-    STATE(443), 1,
+    STATE(441), 1,
       sym__4d,
-    ACTIONS(142), 2,
+    ACTIONS(57), 2,
       anon_sym_o,
       anon_sym_O,
     STATE(3), 2,
       sym_journal_item,
       aux_sym_source_file_repeat1,
-    STATE(430), 2,
+    STATE(462), 2,
       sym_word_directive,
       sym_char_directive,
-    STATE(463), 2,
+    STATE(473), 2,
       sym_check_in,
       sym_check_out,
-    STATE(78), 3,
+    STATE(77), 3,
       sym_plain_xact,
       sym_periodic_xact,
       sym_automated_xact,
-    STATE(85), 4,
-      sym_option,
-      sym_account_directive,
-      sym_commodity_directive,
-      sym_tag_directive,
-    STATE(86), 4,
+    STATE(76), 4,
       sym_block_comment,
       sym_test,
       sym_directive,
       sym_xact,
-  [260] = 6,
-    STATE(135), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(155), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(5), 2,
-      sym_account_subdirective,
-      aux_sym_account_directive_repeat1,
-    ACTIONS(153), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    STATE(50), 5,
-      sym_alias_subdirective,
-      sym_default_subdirective,
-      sym_note_subdirective,
-      sym_assert_subdirective,
-      sym_check_subdirective,
-    ACTIONS(151), 27,
+    STATE(68), 5,
+      sym_option,
+      sym_account_directive,
+      sym_commodity_directive,
+      sym_payee_directive,
+      sym_tag_directive,
+  [134] = 40,
+    ACTIONS(67), 1,
       ts_builtin_sym_end,
+    ACTIONS(69), 1,
       anon_sym_LF,
+    ACTIONS(72), 1,
       sym_comment,
+    ACTIONS(75), 1,
       anon_sym_comment,
+    ACTIONS(78), 1,
       anon_sym_end,
+    ACTIONS(81), 1,
       anon_sym_test,
+    ACTIONS(84), 1,
+      anon_sym_DASH,
+    ACTIONS(87), 1,
       anon_sym_DASH_DASH,
+    ACTIONS(90), 1,
       anon_sym_EQ,
+    ACTIONS(93), 1,
       anon_sym_account,
+    ACTIONS(96), 1,
+      anon_sym_payee,
+    ACTIONS(99), 1,
       anon_sym_commodity,
+    ACTIONS(102), 1,
       anon_sym_tag,
+    ACTIONS(105), 1,
       anon_sym_include,
+    ACTIONS(108), 1,
       anon_sym_alias,
+    ACTIONS(111), 1,
       anon_sym_def,
+    ACTIONS(114), 1,
       anon_sym_year,
+    ACTIONS(117), 1,
       aux_sym_word_directive_token2,
+    ACTIONS(120), 1,
       anon_sym_bucket,
+    ACTIONS(123), 1,
       anon_sym_A,
+    ACTIONS(126), 1,
       anon_sym_Y,
+    ACTIONS(129), 1,
       anon_sym_N,
+    ACTIONS(132), 1,
       anon_sym_D,
+    ACTIONS(135), 1,
       anon_sym_C,
+    ACTIONS(138), 1,
       anon_sym_P,
+    ACTIONS(141), 1,
+      anon_sym_i,
+    ACTIONS(144), 1,
       anon_sym_I,
+    ACTIONS(150), 1,
+      anon_sym_TILDE,
+    ACTIONS(153), 1,
+      sym__2d,
+    STATE(233), 1,
+      sym_date,
+    STATE(237), 1,
+      sym__xact_date,
+    STATE(239), 1,
+      sym__single_date,
+    STATE(441), 1,
+      sym__4d,
+    ACTIONS(147), 2,
       anon_sym_o,
       anon_sym_O,
-      anon_sym_TILDE,
-  [313] = 6,
-    STATE(135), 1,
+    STATE(3), 2,
+      sym_journal_item,
+      aux_sym_source_file_repeat1,
+    STATE(462), 2,
+      sym_word_directive,
+      sym_char_directive,
+    STATE(473), 2,
+      sym_check_in,
+      sym_check_out,
+    STATE(77), 3,
+      sym_plain_xact,
+      sym_periodic_xact,
+      sym_automated_xact,
+    STATE(76), 4,
+      sym_block_comment,
+      sym_test,
+      sym_directive,
+      sym_xact,
+    STATE(68), 5,
+      sym_option,
+      sym_account_directive,
+      sym_commodity_directive,
+      sym_payee_directive,
+      sym_tag_directive,
+  [268] = 6,
+    STATE(129), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(155), 2,
+    ACTIONS(160), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(6), 2,
       sym_account_subdirective,
       aux_sym_account_directive_repeat1,
-    ACTIONS(159), 3,
+    ACTIONS(158), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(50), 5,
+    STATE(31), 5,
       sym_alias_subdirective,
       sym_default_subdirective,
       sym_note_subdirective,
       sym_assert_subdirective,
       sym_check_subdirective,
-    ACTIONS(157), 27,
+    ACTIONS(156), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -6971,6 +6721,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -6989,26 +6740,74 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [366] = 6,
-    STATE(135), 1,
+  [322] = 6,
+    STATE(129), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(165), 2,
+    ACTIONS(160), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(4), 2,
+      sym_account_subdirective,
+      aux_sym_account_directive_repeat1,
+    ACTIONS(164), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    STATE(31), 5,
+      sym_alias_subdirective,
+      sym_default_subdirective,
+      sym_note_subdirective,
+      sym_assert_subdirective,
+      sym_check_subdirective,
+    ACTIONS(162), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [376] = 6,
+    STATE(129), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(170), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(6), 2,
       sym_account_subdirective,
       aux_sym_account_directive_repeat1,
-    ACTIONS(163), 3,
+    ACTIONS(168), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(50), 5,
+    STATE(31), 5,
       sym_alias_subdirective,
       sym_default_subdirective,
       sym_note_subdirective,
       sym_assert_subdirective,
       sym_check_subdirective,
-    ACTIONS(161), 27,
+    ACTIONS(166), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7018,6 +6817,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7036,25 +6836,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [419] = 6,
-    STATE(154), 1,
+  [430] = 6,
+    STATE(148), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(172), 2,
+    ACTIONS(177), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(9), 2,
       sym_commodity_subdirective,
       aux_sym_commodity_directive_repeat1,
-    ACTIONS(170), 3,
+    ACTIONS(175), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(41), 4,
+    STATE(46), 4,
       sym_alias_subdirective,
       sym_default_subdirective,
       sym_format_subdirective,
       sym_note_subdirective,
-    ACTIONS(168), 27,
+    ACTIONS(173), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7064,6 +6864,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7082,25 +6883,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [471] = 6,
-    STATE(154), 1,
+  [483] = 6,
+    STATE(148), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(172), 2,
+    ACTIONS(183), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(7), 2,
+    STATE(8), 2,
       sym_commodity_subdirective,
       aux_sym_commodity_directive_repeat1,
-    ACTIONS(176), 3,
+    ACTIONS(181), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(41), 4,
+    STATE(46), 4,
       sym_alias_subdirective,
       sym_default_subdirective,
       sym_format_subdirective,
       sym_note_subdirective,
-    ACTIONS(174), 27,
+    ACTIONS(179), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7110,6 +6911,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7128,25 +6930,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [523] = 6,
-    STATE(154), 1,
+  [536] = 6,
+    STATE(148), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(182), 2,
+    ACTIONS(177), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(9), 2,
+    STATE(8), 2,
       sym_commodity_subdirective,
       aux_sym_commodity_directive_repeat1,
-    ACTIONS(180), 3,
+    ACTIONS(188), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(41), 4,
+    STATE(46), 4,
       sym_alias_subdirective,
       sym_default_subdirective,
       sym_format_subdirective,
       sym_note_subdirective,
-    ACTIONS(178), 27,
+    ACTIONS(186), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7156,6 +6958,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7174,13 +6977,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [575] = 3,
+  [589] = 3,
     STATE(10), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(187), 2,
+    ACTIONS(192), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(185), 35,
+    ACTIONS(190), 35,
       sym_comment,
       anon_sym_eval,
       anon_sym_payee,
@@ -7216,39 +7019,39 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_last,
       anon_sym_this,
       anon_sym_next,
-  [620] = 7,
-    ACTIONS(194), 1,
-      aux_sym_commodity_token1,
-    STATE(13), 1,
+  [634] = 6,
+    STATE(35), 1,
+      sym_alias_subdirective,
+    STATE(214), 1,
       aux_sym_whitespace_repeat1,
-    STATE(61), 1,
-      sym_commodity,
-    ACTIONS(196), 2,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-    ACTIONS(198), 2,
+    ACTIONS(199), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(190), 7,
+    STATE(14), 2,
+      sym_payee_subdirective,
+      aux_sym_payee_directive_repeat1,
+    ACTIONS(197), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(195), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      anon_sym_TILDE,
-    ACTIONS(192), 23,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
-      anon_sym_DASH,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
       anon_sym_alias,
       anon_sym_def,
       anon_sym_year,
+      aux_sym_word_directive_token2,
       anon_sym_bucket,
       anon_sym_A,
       anon_sym_Y,
@@ -7256,159 +7059,25 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_D,
       anon_sym_C,
       anon_sym_P,
-      anon_sym_i,
       anon_sym_I,
       anon_sym_o,
       anon_sym_O,
-      sym__2d,
-  [672] = 7,
-    ACTIONS(194), 1,
-      aux_sym_commodity_token1,
-    STATE(14), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(62), 1,
-      sym_commodity,
-    ACTIONS(196), 2,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-    ACTIONS(204), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(200), 7,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
       anon_sym_TILDE,
-    ACTIONS(202), 23,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_i,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      sym__2d,
-  [724] = 6,
-    ACTIONS(194), 1,
-      aux_sym_commodity_token1,
-    STATE(18), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(62), 1,
-      sym_commodity,
-    ACTIONS(196), 2,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-    ACTIONS(200), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(202), 23,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_i,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      sym__2d,
-  [774] = 6,
-    ACTIONS(194), 1,
-      aux_sym_commodity_token1,
-    STATE(18), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(63), 1,
-      sym_commodity,
-    ACTIONS(196), 2,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-    ACTIONS(206), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(208), 23,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_i,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      sym__2d,
-  [824] = 5,
+  [684] = 5,
     STATE(234), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(214), 2,
+    ACTIONS(205), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(212), 3,
+    ACTIONS(203), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(15), 3,
+    STATE(16), 3,
       sym_assert_subdirective,
       sym_check_subdirective,
       aux_sym_tag_directive_repeat1,
-    ACTIONS(210), 27,
+    ACTIONS(201), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7418,6 +7087,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7436,21 +7106,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [871] = 5,
+  [732] = 5,
     STATE(234), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(221), 2,
+    ACTIONS(205), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(219), 3,
+    ACTIONS(209), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(17), 3,
+    STATE(12), 3,
       sym_assert_subdirective,
       sym_check_subdirective,
       aux_sym_tag_directive_repeat1,
-    ACTIONS(217), 27,
+    ACTIONS(207), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7460,6 +7130,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7478,21 +7149,109 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [918] = 5,
-    STATE(234), 1,
+  [780] = 6,
+    STATE(35), 1,
+      sym_alias_subdirective,
+    STATE(214), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(221), 2,
+    ACTIONS(199), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(225), 3,
+    STATE(15), 2,
+      sym_payee_subdirective,
+      aux_sym_payee_directive_repeat1,
+    ACTIONS(213), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    STATE(15), 3,
+    ACTIONS(211), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [830] = 6,
+    STATE(35), 1,
+      sym_alias_subdirective,
+    STATE(214), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(219), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(15), 2,
+      sym_payee_subdirective,
+      aux_sym_payee_directive_repeat1,
+    ACTIONS(217), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(215), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [880] = 5,
+    STATE(234), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(226), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(224), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    STATE(16), 3,
       sym_assert_subdirective,
       sym_check_subdirective,
       aux_sym_tag_directive_repeat1,
-    ACTIONS(223), 27,
+    ACTIONS(222), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7502,6 +7261,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7520,61 +7280,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [965] = 4,
-    STATE(18), 1,
+  [928] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(229), 2,
+    ACTIONS(233), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(185), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      anon_sym_TILDE,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-    ACTIONS(227), 24,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_i,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      sym__2d,
-      aux_sym_commodity_token1,
-  [1010] = 5,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(234), 3,
+    ACTIONS(231), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(232), 27,
+    ACTIONS(229), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7584,6 +7303,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7602,20 +7322,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1056] = 5,
-    STATE(121), 1,
+  [975] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(240), 3,
+    ACTIONS(238), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(238), 27,
+    ACTIONS(236), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7625,6 +7345,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7643,20 +7364,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1102] = 5,
-    STATE(121), 1,
+  [1022] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(246), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
     ACTIONS(244), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(242), 27,
+    ACTIONS(242), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7666,6 +7387,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7684,20 +7406,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1148] = 5,
-    STATE(121), 1,
+  [1069] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(251), 3,
+    ACTIONS(248), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(249), 27,
+    ACTIONS(246), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7707,6 +7429,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7725,20 +7448,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1194] = 5,
-    STATE(121), 1,
+  [1116] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(255), 3,
+    ACTIONS(252), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(253), 27,
+    ACTIONS(250), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7748,6 +7471,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7766,20 +7490,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1240] = 5,
-    STATE(121), 1,
+  [1163] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(259), 3,
+    ACTIONS(256), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(257), 27,
+    ACTIONS(254), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7789,6 +7513,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7807,20 +7532,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1286] = 5,
-    STATE(121), 1,
+  [1210] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(263), 3,
+    ACTIONS(260), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(261), 27,
+    ACTIONS(258), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7830,6 +7555,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7848,20 +7574,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1332] = 5,
-    STATE(121), 1,
+  [1257] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(267), 3,
+    ACTIONS(264), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(265), 27,
+    ACTIONS(262), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7871,6 +7597,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7889,20 +7616,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1378] = 5,
-    STATE(121), 1,
+  [1304] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(271), 3,
+    ACTIONS(268), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(269), 27,
+    ACTIONS(266), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7912,6 +7639,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -7930,58 +7658,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1424] = 2,
-    ACTIONS(273), 11,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      anon_sym_TILDE,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(275), 24,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_i,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      sym__2d,
-      aux_sym_commodity_token1,
-  [1464] = 5,
-    STATE(121), 1,
+  [1351] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(279), 3,
+    ACTIONS(272), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(277), 27,
+    ACTIONS(270), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -7991,6 +7681,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8009,58 +7700,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1510] = 2,
-    ACTIONS(281), 11,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      anon_sym_TILDE,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(283), 24,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_i,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      sym__2d,
-      aux_sym_commodity_token1,
-  [1550] = 5,
-    STATE(121), 1,
+  [1398] = 5,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    STATE(21), 2,
+    STATE(17), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-    ACTIONS(287), 3,
+    ACTIONS(276), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(285), 27,
+    ACTIONS(274), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8070,6 +7723,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8088,12 +7742,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [1596] = 2,
-    ACTIONS(283), 3,
+  [1445] = 2,
+    ACTIONS(280), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(281), 29,
+    ACTIONS(278), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8103,41 +7757,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [1633] = 2,
-    ACTIONS(180), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(178), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8158,12 +7778,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1670] = 2,
-    ACTIONS(291), 3,
+  [1483] = 2,
+    ACTIONS(284), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(289), 29,
+    ACTIONS(282), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8173,6 +7793,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8193,55 +7814,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1707] = 10,
-    STATE(10), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(272), 1,
-      sym__interval_period,
-    STATE(376), 1,
-      sym_interval,
-    STATE(407), 1,
-      sym__interval_date_spec,
-    STATE(408), 1,
-      sym__relative_date_spec,
-    ACTIONS(295), 2,
-      aux_sym__interval_date_spec_token1,
-      aux_sym__interval_date_spec_token2,
-    ACTIONS(301), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(297), 3,
-      aux_sym__interval_date_spec_token3,
-      aux_sym__interval_date_spec_token4,
-      aux_sym__interval_date_spec_token5,
-    ACTIONS(299), 3,
-      anon_sym_last,
-      anon_sym_this,
-      anon_sym_next,
-    ACTIONS(293), 17,
-      aux_sym__interval_period_token1,
-      aux_sym__interval_period_token2,
-      aux_sym__interval_period_token3,
-      aux_sym__interval_period_token4,
-      aux_sym__interval_period_token5,
-      aux_sym__interval_period_token6,
-      aux_sym__interval_period_token7,
-      aux_sym__interval_period_token8,
-      aux_sym__interval_period_token9,
-      aux_sym__interval_period_token10,
-      aux_sym__interval_period_token11,
-      aux_sym__interval_period_token12,
-      aux_sym__interval_period_token13,
-      aux_sym__interval_period_token14,
-      aux_sym__interval_period_token15,
-      aux_sym__interval_period_token16,
-      aux_sym__interval_period_token17,
-  [1760] = 2,
-    ACTIONS(305), 3,
+  [1521] = 2,
+    ACTIONS(168), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(303), 29,
+    ACTIONS(166), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8251,6 +7829,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8271,12 +7850,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1797] = 2,
-    ACTIONS(309), 3,
+  [1559] = 2,
+    ACTIONS(288), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(307), 29,
+    ACTIONS(286), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8286,6 +7865,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8306,12 +7886,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1834] = 2,
-    ACTIONS(313), 3,
+  [1597] = 2,
+    ACTIONS(217), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(311), 29,
+    ACTIONS(215), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8321,6 +7901,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8341,12 +7922,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1871] = 2,
-    ACTIONS(317), 3,
+  [1635] = 2,
+    ACTIONS(181), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(315), 29,
+    ACTIONS(179), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8356,6 +7937,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8376,12 +7958,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1908] = 2,
-    ACTIONS(321), 3,
+  [1673] = 2,
+    ACTIONS(292), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(319), 29,
+    ACTIONS(290), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8391,6 +7973,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8411,12 +7994,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1945] = 2,
-    ACTIONS(325), 3,
+  [1711] = 2,
+    ACTIONS(296), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(323), 29,
+    ACTIONS(294), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8426,6 +8009,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8446,12 +8030,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [1982] = 2,
-    ACTIONS(329), 3,
+  [1749] = 2,
+    ACTIONS(300), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(327), 29,
+    ACTIONS(298), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8461,6 +8045,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8481,12 +8066,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2019] = 2,
-    ACTIONS(333), 3,
+  [1787] = 2,
+    ACTIONS(304), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(331), 29,
+    ACTIONS(302), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8496,6 +8081,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8516,12 +8102,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2056] = 2,
-    ACTIONS(337), 3,
+  [1825] = 2,
+    ACTIONS(308), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(335), 29,
+    ACTIONS(306), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8531,6 +8117,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8551,12 +8138,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2093] = 2,
-    ACTIONS(341), 3,
+  [1863] = 2,
+    ACTIONS(312), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(339), 29,
+    ACTIONS(310), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8566,6 +8153,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8586,12 +8174,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2130] = 2,
-    ACTIONS(345), 3,
+  [1901] = 2,
+    ACTIONS(316), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(343), 29,
+    ACTIONS(314), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8601,6 +8189,223 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [1939] = 2,
+    ACTIONS(320), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(318), 30,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [1977] = 2,
+    ACTIONS(324), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(322), 30,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [2015] = 2,
+    ACTIONS(328), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(326), 30,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [2053] = 2,
+    ACTIONS(332), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(330), 30,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [2091] = 2,
+    ACTIONS(336), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(334), 30,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [2129] = 2,
+    ACTIONS(340), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(338), 30,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8622,11 +8427,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SPACE,
       anon_sym_TAB,
   [2167] = 2,
-    ACTIONS(349), 3,
+    ACTIONS(344), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(347), 29,
+    ACTIONS(342), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8636,6 +8441,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8656,12 +8462,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2204] = 2,
-    ACTIONS(353), 3,
+  [2205] = 2,
+    ACTIONS(348), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(351), 29,
+    ACTIONS(346), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8671,6 +8477,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8691,12 +8498,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2241] = 2,
-    ACTIONS(212), 3,
+  [2243] = 2,
+    ACTIONS(352), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(210), 29,
+    ACTIONS(350), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8706,6 +8513,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8726,12 +8534,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2278] = 2,
-    ACTIONS(357), 3,
+  [2281] = 2,
+    ACTIONS(356), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(355), 29,
+    ACTIONS(354), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8741,6 +8549,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8761,12 +8570,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2315] = 2,
-    ACTIONS(361), 3,
+  [2319] = 2,
+    ACTIONS(360), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(359), 29,
+    ACTIONS(358), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8776,6 +8585,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8796,12 +8606,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2352] = 2,
-    ACTIONS(365), 3,
+  [2357] = 2,
+    ACTIONS(364), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(363), 29,
+    ACTIONS(362), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8811,6 +8621,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8831,12 +8642,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2389] = 2,
-    ACTIONS(369), 3,
+  [2395] = 2,
+    ACTIONS(368), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(367), 29,
+    ACTIONS(366), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8846,6 +8657,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8866,12 +8678,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2426] = 2,
-    ACTIONS(373), 3,
+  [2433] = 2,
+    ACTIONS(224), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(371), 29,
+    ACTIONS(222), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8881,6 +8693,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8901,12 +8714,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2463] = 2,
-    ACTIONS(377), 3,
+  [2471] = 2,
+    ACTIONS(372), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(375), 29,
+    ACTIONS(370), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8916,6 +8729,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8936,12 +8750,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2500] = 2,
-    ACTIONS(381), 3,
+  [2509] = 2,
+    ACTIONS(376), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(379), 29,
+    ACTIONS(374), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8951,6 +8765,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -8971,12 +8786,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2537] = 2,
-    ACTIONS(385), 3,
+  [2547] = 2,
+    ACTIONS(380), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(383), 29,
+    ACTIONS(378), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -8986,6 +8801,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9006,12 +8822,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2574] = 2,
-    ACTIONS(389), 3,
+  [2585] = 2,
+    ACTIONS(384), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(387), 29,
+    ACTIONS(382), 30,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9021,6 +8837,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9041,329 +8858,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [2611] = 2,
-    ACTIONS(393), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(391), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2648] = 2,
-    ACTIONS(397), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(395), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2685] = 2,
-    ACTIONS(202), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(200), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2722] = 2,
-    ACTIONS(208), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(206), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2759] = 2,
-    ACTIONS(401), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(399), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2796] = 2,
-    ACTIONS(405), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(403), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2833] = 2,
-    ACTIONS(275), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(273), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2870] = 2,
-    ACTIONS(163), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(161), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2907] = 2,
-    ACTIONS(409), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(407), 29,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [2944] = 3,
-    ACTIONS(415), 1,
+  [2623] = 3,
+    ACTIONS(390), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(411), 3,
+    ACTIONS(386), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(413), 27,
+    ACTIONS(388), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9371,6 +8873,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9391,14 +8894,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [2982] = 3,
-    ACTIONS(421), 1,
+  [2662] = 3,
+    ACTIONS(396), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(417), 3,
+    ACTIONS(392), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(419), 27,
+    ACTIONS(394), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9406,6 +8909,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9426,14 +8930,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3020] = 3,
-    ACTIONS(427), 1,
+  [2701] = 3,
+    ACTIONS(402), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(423), 3,
+    ACTIONS(398), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(425), 27,
+    ACTIONS(400), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9441,6 +8945,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9461,14 +8966,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3058] = 3,
-    ACTIONS(433), 1,
+  [2740] = 3,
+    ACTIONS(408), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(429), 3,
+    ACTIONS(404), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(431), 27,
+    ACTIONS(406), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9476,6 +8981,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9496,14 +9002,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3096] = 3,
-    ACTIONS(439), 1,
+  [2779] = 3,
+    ACTIONS(414), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(435), 3,
+    ACTIONS(410), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(437), 27,
+    ACTIONS(412), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9511,6 +9017,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9531,14 +9038,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3134] = 3,
-    ACTIONS(445), 1,
+  [2818] = 3,
+    ACTIONS(420), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(441), 3,
+    ACTIONS(416), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(443), 27,
+    ACTIONS(418), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9546,6 +9053,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9566,14 +9074,57 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3172] = 3,
-    ACTIONS(451), 1,
+  [2857] = 10,
+    STATE(10), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(269), 1,
+      sym__interval_period,
+    STATE(392), 1,
+      sym_interval,
+    STATE(399), 1,
+      sym__interval_date_spec,
+    STATE(400), 1,
+      sym__relative_date_spec,
+    ACTIONS(424), 2,
+      aux_sym__interval_date_spec_token1,
+      aux_sym__interval_date_spec_token2,
+    ACTIONS(430), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(426), 3,
+      aux_sym__interval_date_spec_token3,
+      aux_sym__interval_date_spec_token4,
+      aux_sym__interval_date_spec_token5,
+    ACTIONS(428), 3,
+      anon_sym_last,
+      anon_sym_this,
+      anon_sym_next,
+    ACTIONS(422), 17,
+      aux_sym__interval_period_token1,
+      aux_sym__interval_period_token2,
+      aux_sym__interval_period_token3,
+      aux_sym__interval_period_token4,
+      aux_sym__interval_period_token5,
+      aux_sym__interval_period_token6,
+      aux_sym__interval_period_token7,
+      aux_sym__interval_period_token8,
+      aux_sym__interval_period_token9,
+      aux_sym__interval_period_token10,
+      aux_sym__interval_period_token11,
+      aux_sym__interval_period_token12,
+      aux_sym__interval_period_token13,
+      aux_sym__interval_period_token14,
+      aux_sym__interval_period_token15,
+      aux_sym__interval_period_token16,
+      aux_sym__interval_period_token17,
+  [2910] = 3,
+    ACTIONS(436), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(447), 3,
+    ACTIONS(432), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(449), 27,
+    ACTIONS(434), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9581,6 +9132,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9601,14 +9153,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3210] = 3,
-    ACTIONS(457), 1,
+  [2949] = 3,
+    ACTIONS(442), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(453), 3,
+    ACTIONS(438), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
-    ACTIONS(455), 27,
+    ACTIONS(440), 28,
       anon_sym_comment,
       anon_sym_end,
       anon_sym_test,
@@ -9616,6 +9168,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9636,12 +9189,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
       sym__2d,
-  [3248] = 2,
-    ACTIONS(437), 3,
+  [2988] = 2,
+    ACTIONS(446), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(435), 27,
+    ACTIONS(444), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9651,6 +9204,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9669,12 +9223,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3283] = 2,
-    ACTIONS(461), 3,
+  [3024] = 2,
+    ACTIONS(434), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(459), 27,
+    ACTIONS(432), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9684,6 +9238,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9702,12 +9257,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3318] = 2,
-    ACTIONS(465), 3,
+  [3060] = 2,
+    ACTIONS(450), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(463), 27,
+    ACTIONS(448), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9717,6 +9272,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9735,12 +9291,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3353] = 2,
-    ACTIONS(449), 3,
+  [3096] = 2,
+    ACTIONS(400), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(447), 27,
+    ACTIONS(398), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9750,6 +9306,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9768,12 +9325,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3388] = 2,
-    ACTIONS(455), 3,
+  [3132] = 2,
+    ACTIONS(418), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(453), 27,
+    ACTIONS(416), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9783,6 +9340,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9801,12 +9359,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3423] = 2,
-    ACTIONS(431), 3,
+  [3168] = 2,
+    ACTIONS(440), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(429), 27,
+    ACTIONS(438), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9816,6 +9374,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9834,12 +9393,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3458] = 2,
-    ACTIONS(419), 3,
+  [3204] = 2,
+    ACTIONS(388), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(417), 27,
+    ACTIONS(386), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9849,6 +9408,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9867,12 +9427,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3493] = 2,
-    ACTIONS(425), 3,
+  [3240] = 2,
+    ACTIONS(454), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(423), 27,
+    ACTIONS(452), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9882,6 +9442,245 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3276] = 2,
+    ACTIONS(458), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(456), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3312] = 2,
+    ACTIONS(462), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(460), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3348] = 2,
+    ACTIONS(394), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(392), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3384] = 2,
+    ACTIONS(406), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(404), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3420] = 2,
+    ACTIONS(466), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(464), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3456] = 2,
+    ACTIONS(470), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(468), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
+      anon_sym_commodity,
+      anon_sym_tag,
+      anon_sym_include,
+      anon_sym_alias,
+      anon_sym_def,
+      anon_sym_year,
+      aux_sym_word_directive_token2,
+      anon_sym_bucket,
+      anon_sym_A,
+      anon_sym_Y,
+      anon_sym_N,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_P,
+      anon_sym_I,
+      anon_sym_o,
+      anon_sym_O,
+      anon_sym_TILDE,
+  [3492] = 2,
+    ACTIONS(412), 3,
+      anon_sym_DASH,
+      anon_sym_i,
+      sym__2d,
+    ACTIONS(410), 28,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      sym_comment,
+      anon_sym_comment,
+      anon_sym_end,
+      anon_sym_test,
+      anon_sym_DASH_DASH,
+      anon_sym_EQ,
+      anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9901,11 +9700,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_O,
       anon_sym_TILDE,
   [3528] = 2,
-    ACTIONS(469), 3,
+    ACTIONS(474), 3,
       anon_sym_DASH,
       anon_sym_i,
       sym__2d,
-    ACTIONS(467), 27,
+    ACTIONS(472), 28,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_comment,
@@ -9915,6 +9714,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH_DASH,
       anon_sym_EQ,
       anon_sym_account,
+      anon_sym_payee,
       anon_sym_commodity,
       anon_sym_tag,
       anon_sym_include,
@@ -9933,531 +9733,279 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_o,
       anon_sym_O,
       anon_sym_TILDE,
-  [3563] = 2,
-    ACTIONS(473), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(471), 27,
-      ts_builtin_sym_end,
+  [3564] = 20,
+    ACTIONS(476), 1,
       anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3598] = 2,
-    ACTIONS(477), 3,
+    ACTIONS(478), 1,
       anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(475), 27,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3633] = 2,
-    ACTIONS(443), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(441), 27,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3668] = 2,
-    ACTIONS(481), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(479), 27,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3703] = 2,
-    ACTIONS(485), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(483), 27,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3738] = 2,
-    ACTIONS(489), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(487), 27,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3773] = 2,
-    ACTIONS(413), 3,
-      anon_sym_DASH,
-      anon_sym_i,
-      sym__2d,
-    ACTIONS(411), 27,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      sym_comment,
-      anon_sym_comment,
-      anon_sym_end,
-      anon_sym_test,
-      anon_sym_DASH_DASH,
-      anon_sym_EQ,
-      anon_sym_account,
-      anon_sym_commodity,
-      anon_sym_tag,
-      anon_sym_include,
-      anon_sym_alias,
-      anon_sym_def,
-      anon_sym_year,
-      aux_sym_word_directive_token2,
-      anon_sym_bucket,
-      anon_sym_A,
-      anon_sym_Y,
-      anon_sym_N,
-      anon_sym_D,
-      anon_sym_C,
-      anon_sym_P,
-      anon_sym_I,
-      anon_sym_o,
-      anon_sym_O,
-      anon_sym_TILDE,
-  [3808] = 20,
-    ACTIONS(491), 1,
-      anon_sym_LF,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(499), 1,
+    ACTIONS(484), 1,
       anon_sym_PLUS,
-    ACTIONS(501), 1,
+    ACTIONS(486), 1,
       sym__quantity,
-    ACTIONS(505), 1,
+    ACTIONS(490), 1,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(97), 1,
+    STATE(89), 1,
       aux_sym_whitespace_repeat1,
-    STATE(103), 1,
+    STATE(96), 1,
       sym_quantity,
-    STATE(108), 1,
+    STATE(103), 1,
       sym_amount,
-    STATE(136), 1,
+    STATE(127), 1,
       sym_lot_price,
-    STATE(173), 1,
+    STATE(159), 1,
       sym_price,
-    STATE(220), 1,
+    STATE(203), 1,
       sym_commodity,
     STATE(225), 1,
       sym_balance_assertion,
     STATE(465), 1,
       sym_note,
-    ACTIONS(513), 2,
+    ACTIONS(498), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [3872] = 20,
-    ACTIONS(493), 1,
+  [3628] = 20,
+    ACTIONS(478), 1,
       anon_sym_DASH,
-    ACTIONS(495), 1,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(499), 1,
+    ACTIONS(484), 1,
       anon_sym_PLUS,
-    ACTIONS(501), 1,
+    ACTIONS(486), 1,
       sym__quantity,
-    ACTIONS(505), 1,
+    ACTIONS(490), 1,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    ACTIONS(515), 1,
+    ACTIONS(500), 1,
       anon_sym_LF,
+    STATE(87), 1,
+      aux_sym_whitespace_repeat1,
     STATE(96), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(103), 1,
       sym_quantity,
-    STATE(110), 1,
+    STATE(100), 1,
       sym_amount,
-    STATE(144), 1,
+    STATE(136), 1,
       sym_lot_price,
-    STATE(186), 1,
+    STATE(178), 1,
       sym_price,
-    STATE(220), 1,
+    STATE(203), 1,
       sym_commodity,
-    STATE(235), 1,
+    STATE(230), 1,
       sym_balance_assertion,
-    STATE(456), 1,
+    STATE(448), 1,
       sym_note,
-    ACTIONS(517), 2,
+    ACTIONS(502), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [3936] = 20,
-    ACTIONS(493), 1,
+  [3692] = 20,
+    ACTIONS(478), 1,
       anon_sym_DASH,
-    ACTIONS(495), 1,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(499), 1,
+    ACTIONS(484), 1,
       anon_sym_PLUS,
-    ACTIONS(501), 1,
+    ACTIONS(486), 1,
       sym__quantity,
-    ACTIONS(505), 1,
+    ACTIONS(490), 1,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    ACTIONS(519), 1,
+    ACTIONS(504), 1,
       anon_sym_LF,
-    STATE(95), 1,
+    STATE(88), 1,
       aux_sym_whitespace_repeat1,
-    STATE(103), 1,
+    STATE(96), 1,
       sym_quantity,
-    STATE(111), 1,
-      sym_amount,
-    STATE(137), 1,
-      sym_lot_price,
-    STATE(163), 1,
-      sym_price,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(236), 1,
-      sym_balance_assertion,
-    STATE(490), 1,
-      sym_note,
-    ACTIONS(521), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [4000] = 19,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(109), 1,
-      sym_amount,
-    STATE(138), 1,
-      sym_lot_price,
-    STATE(167), 1,
-      sym_price,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(237), 1,
-      sym_balance_assertion,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [4061] = 19,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(111), 1,
-      sym_amount,
-    STATE(137), 1,
-      sym_lot_price,
-    STATE(163), 1,
-      sym_price,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(236), 1,
-      sym_balance_assertion,
-    STATE(490), 1,
-      sym_note,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [4122] = 19,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(110), 1,
-      sym_amount,
-    STATE(144), 1,
-      sym_lot_price,
-    STATE(186), 1,
-      sym_price,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(235), 1,
-      sym_balance_assertion,
-    STATE(456), 1,
-      sym_note,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [4183] = 4,
     STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(525), 2,
+      sym_amount,
+    STATE(132), 1,
+      sym_lot_price,
+    STATE(180), 1,
+      sym_price,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(218), 1,
+      sym_balance_assertion,
+    STATE(447), 1,
+      sym_note,
+    ACTIONS(506), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(227), 4,
-      sym__2d,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(185), 11,
-      anon_sym_LF,
-      anon_sym_EQ,
-      aux_sym_word_directive_token2,
-      sym_time,
-      anon_sym_SEMI,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
+  [3756] = 19,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-  [4210] = 4,
-    STATE(99), 1,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(528), 2,
+    STATE(103), 1,
+      sym_amount,
+    STATE(127), 1,
+      sym_lot_price,
+    STATE(159), 1,
+      sym_price,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(225), 1,
+      sym_balance_assertion,
+    STATE(465), 1,
+      sym_note,
+    ACTIONS(508), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(185), 5,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [3817] = 19,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(100), 1,
+      sym_amount,
+    STATE(136), 1,
+      sym_lot_price,
+    STATE(178), 1,
+      sym_price,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(230), 1,
+      sym_balance_assertion,
+    STATE(448), 1,
+      sym_note,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [3878] = 19,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(102), 1,
+      sym_amount,
+    STATE(130), 1,
+      sym_lot_price,
+    STATE(163), 1,
+      sym_price,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(235), 1,
+      sym_balance_assertion,
+    STATE(459), 1,
+      sym_note,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [3939] = 4,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(512), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(190), 5,
       sym_comment,
       anon_sym_DASH,
       aux_sym_tag_directive_token1,
       anon_sym_PLUS,
       sym__quantity,
-    ACTIONS(227), 10,
+    ACTIONS(510), 12,
+      anon_sym_uuid,
+      anon_sym_alias,
       anon_sym_assert,
       anon_sym_check,
       aux_sym__interval_date_spec_token1,
@@ -10468,12 +10016,35 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_last,
       anon_sym_this,
       anon_sym_next,
-  [4237] = 2,
-    ACTIONS(389), 3,
+  [3968] = 4,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(515), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(510), 4,
+      sym__2d,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_AT,
-    ACTIONS(387), 14,
+    ACTIONS(190), 11,
+      anon_sym_LF,
+      anon_sym_EQ,
+      aux_sym_word_directive_token2,
+      sym_time,
+      anon_sym_SEMI,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+      anon_sym_AT_AT,
+  [3995] = 2,
+    ACTIONS(520), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(518), 14,
       anon_sym_LF,
       anon_sym_DASH,
       anon_sym_EQ,
@@ -10488,42 +10059,43 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT_AT,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4259] = 5,
-    STATE(98), 1,
+  [4017] = 6,
+    STATE(94), 1,
       aux_sym_whitespace_repeat1,
-    STATE(143), 1,
+    STATE(134), 1,
       sym_commodity,
-    ACTIONS(202), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(503), 3,
+    ACTIONS(526), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-    ACTIONS(200), 8,
+    ACTIONS(524), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(522), 6,
       anon_sym_LF,
       anon_sym_EQ,
       anon_sym_SEMI,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [4286] = 5,
-    STATE(98), 1,
+  [4046] = 5,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(145), 1,
+    STATE(133), 1,
       sym_commodity,
-    ACTIONS(208), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-    ACTIONS(206), 8,
+    ACTIONS(530), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(528), 8,
       anon_sym_LF,
       anon_sym_EQ,
       anon_sym_SEMI,
@@ -10532,945 +10104,771 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT_AT,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4313] = 6,
-    STATE(101), 1,
+  [4073] = 5,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(141), 1,
+    STATE(134), 1,
       sym_commodity,
-    ACTIONS(531), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(192), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-    ACTIONS(190), 6,
+    ACTIONS(524), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(522), 8,
       anon_sym_LF,
       anon_sym_EQ,
       anon_sym_SEMI,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       anon_sym_AT_AT,
-  [4342] = 6,
-    STATE(102), 1,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [4100] = 6,
+    STATE(95), 1,
       aux_sym_whitespace_repeat1,
-    STATE(143), 1,
+    STATE(128), 1,
       sym_commodity,
-    ACTIONS(533), 2,
+    ACTIONS(536), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(202), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-    ACTIONS(200), 6,
+    ACTIONS(534), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(532), 6,
       anon_sym_LF,
       anon_sym_EQ,
       anon_sym_SEMI,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       anon_sym_AT_AT,
-  [4371] = 4,
-    STATE(105), 1,
+  [4129] = 4,
+    STATE(97), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(227), 2,
+    ACTIONS(510), 2,
       anon_sym_LBRACE,
       anon_sym_AT,
-    ACTIONS(535), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(185), 10,
-      anon_sym_DASH,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_PLUS,
-      sym__quantity,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_AT_AT,
-  [4395] = 2,
-    ACTIONS(283), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(281), 11,
-      anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [4414] = 2,
-    ACTIONS(275), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(273), 11,
-      anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [4433] = 13,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(515), 1,
-      anon_sym_LF,
-    STATE(114), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(144), 1,
-      sym_lot_price,
-    STATE(186), 1,
-      sym_price,
-    STATE(235), 1,
-      sym_balance_assertion,
-    STATE(456), 1,
-      sym_note,
     ACTIONS(538), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4474] = 13,
-    ACTIONS(495), 1,
+    ACTIONS(190), 10,
+      anon_sym_DASH,
       anon_sym_EQ,
-    ACTIONS(497), 1,
       anon_sym_SEMI,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
+      anon_sym_PLUS,
+      sym__quantity,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
       anon_sym_AT_AT,
-    ACTIONS(540), 1,
+  [4153] = 13,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    ACTIONS(500), 1,
       anon_sym_LF,
-    STATE(117), 1,
+    STATE(107), 1,
       aux_sym_whitespace_repeat1,
-    STATE(140), 1,
+    STATE(136), 1,
       sym_lot_price,
-    STATE(171), 1,
+    STATE(178), 1,
       sym_price,
-    STATE(238), 1,
+    STATE(230), 1,
       sym_balance_assertion,
-    STATE(469), 1,
+    STATE(448), 1,
       sym_note,
-    ACTIONS(542), 2,
+    ACTIONS(541), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4515] = 13,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(505), 1,
+  [4194] = 2,
+    ACTIONS(545), 3,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+      anon_sym_RBRACE,
       anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(519), 1,
+    ACTIONS(543), 11,
       anon_sym_LF,
-    STATE(113), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(137), 1,
-      sym_lot_price,
-    STATE(163), 1,
-      sym_price,
-    STATE(236), 1,
-      sym_balance_assertion,
-    STATE(490), 1,
-      sym_note,
-    ACTIONS(544), 2,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+      anon_sym_AT_AT,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4556] = 13,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(546), 1,
+  [4213] = 13,
+    ACTIONS(476), 1,
       anon_sym_LF,
-    STATE(115), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(138), 1,
-      sym_lot_price,
-    STATE(167), 1,
-      sym_price,
-    STATE(237), 1,
-      sym_balance_assertion,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(548), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [4597] = 9,
-    ACTIONS(59), 1,
-      sym__2d,
-    ACTIONS(550), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(552), 1,
-      sym__month,
-    STATE(152), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(265), 1,
-      sym__4d,
-    STATE(414), 1,
-      sym_date_spec,
-    ACTIONS(556), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(362), 2,
-      sym__relative_date_spec,
-      sym__single_date,
-    ACTIONS(554), 3,
-      anon_sym_last,
-      anon_sym_this,
-      anon_sym_next,
-  [4629] = 12,
-    ACTIONS(495), 1,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(505), 1,
+    ACTIONS(490), 1,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    STATE(109), 1,
       aux_sym_whitespace_repeat1,
-    STATE(138), 1,
+    STATE(127), 1,
       sym_lot_price,
-    STATE(167), 1,
+    STATE(159), 1,
       sym_price,
-    STATE(237), 1,
+    STATE(225), 1,
       sym_balance_assertion,
-    STATE(478), 1,
+    STATE(465), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(547), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4667] = 12,
-    ACTIONS(495), 1,
+  [4254] = 2,
+    ACTIONS(551), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(549), 11,
+      anon_sym_LF,
       anon_sym_EQ,
-    ACTIONS(497), 1,
       anon_sym_SEMI,
-    ACTIONS(505), 1,
-      anon_sym_LBRACE,
-    ACTIONS(507), 1,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
+      anon_sym_RBRACE_RBRACE,
       anon_sym_AT_AT,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(137), 1,
-      sym_lot_price,
-    STATE(163), 1,
-      sym_price,
-    STATE(236), 1,
-      sym_balance_assertion,
-    STATE(490), 1,
-      sym_note,
-    ACTIONS(558), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4705] = 12,
-    ACTIONS(495), 1,
+  [4273] = 13,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(505), 1,
+    ACTIONS(490), 1,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    ACTIONS(553), 1,
+      anon_sym_LF,
+    STATE(108), 1,
       aux_sym_whitespace_repeat1,
-    STATE(140), 1,
+    STATE(131), 1,
       sym_lot_price,
-    STATE(171), 1,
+    STATE(166), 1,
       sym_price,
-    STATE(238), 1,
+    STATE(232), 1,
       sym_balance_assertion,
-    STATE(469), 1,
+    STATE(437), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(555), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [4743] = 7,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(408), 1,
-      sym__relative_date_spec,
-    STATE(419), 1,
-      sym__interval_date_spec,
-    ACTIONS(295), 2,
-      aux_sym__interval_date_spec_token1,
-      aux_sym__interval_date_spec_token2,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(297), 3,
-      aux_sym__interval_date_spec_token3,
-      aux_sym__interval_date_spec_token4,
-      aux_sym__interval_date_spec_token5,
-    ACTIONS(299), 3,
-      anon_sym_last,
-      anon_sym_this,
-      anon_sym_next,
-  [4771] = 12,
-    ACTIONS(495), 1,
+  [4314] = 13,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(505), 1,
+    ACTIONS(490), 1,
       anon_sym_LBRACE,
-    ACTIONS(507), 1,
+    ACTIONS(492), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    ACTIONS(557), 1,
+      anon_sym_LF,
+    STATE(110), 1,
       aux_sym_whitespace_repeat1,
-    STATE(139), 1,
-      sym_lot_price,
-    STATE(176), 1,
-      sym_price,
-    STATE(241), 1,
-      sym_balance_assertion,
-    STATE(432), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [4809] = 9,
-    ACTIONS(59), 1,
-      sym__2d,
-    ACTIONS(550), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(552), 1,
-      sym__month,
-    STATE(152), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(265), 1,
-      sym__4d,
-    STATE(420), 1,
-      sym_date_spec,
-    ACTIONS(556), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(362), 2,
-      sym__relative_date_spec,
-      sym__single_date,
-    ACTIONS(554), 3,
-      anon_sym_last,
-      anon_sym_this,
-      anon_sym_next,
-  [4841] = 9,
-    ACTIONS(59), 1,
-      sym__2d,
-    ACTIONS(550), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(552), 1,
-      sym__month,
-    STATE(152), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(265), 1,
-      sym__4d,
-    STATE(298), 1,
-      sym_date_spec,
-    ACTIONS(556), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(362), 2,
-      sym__relative_date_spec,
-      sym__single_date,
-    ACTIONS(554), 3,
-      anon_sym_last,
-      anon_sym_this,
-      anon_sym_next,
-  [4873] = 9,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(562), 1,
-      anon_sym_DASH,
-    ACTIONS(564), 1,
-      anon_sym_PLUS,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(184), 1,
-      sym_quantity,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(483), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [4904] = 11,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(574), 1,
-      anon_sym_SPACE,
-    ACTIONS(576), 1,
-      anon_sym_TAB,
-    STATE(155), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(190), 1,
-      sym_status,
-    STATE(259), 1,
-      sym_account,
-    STATE(429), 1,
-      sym_note,
-    ACTIONS(566), 2,
-      anon_sym_STAR,
-      anon_sym_BANG,
-  [4939] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(126), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(287), 1,
-      sym_amount,
-    ACTIONS(578), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [4970] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(317), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5001] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(320), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5032] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(322), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5063] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(256), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5094] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(124), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(303), 1,
-      sym_amount,
-    ACTIONS(580), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5125] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(123), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(302), 1,
-      sym_amount,
-    ACTIONS(582), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5156] = 9,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(562), 1,
-      anon_sym_DASH,
-    ACTIONS(564), 1,
-      anon_sym_PLUS,
     STATE(130), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(184), 1,
-      sym_quantity,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(466), 1,
-      sym_amount,
-    ACTIONS(584), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5187] = 9,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(562), 1,
-      anon_sym_DASH,
-    ACTIONS(564), 1,
-      anon_sym_PLUS,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(184), 1,
-      sym_quantity,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(450), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5218] = 9,
-    ACTIONS(586), 1,
-      anon_sym_DASH,
-    ACTIONS(588), 1,
-      anon_sym_PLUS,
-    ACTIONS(590), 1,
-      sym__quantity,
-    STATE(11), 1,
-      sym_quantity,
-    STATE(45), 1,
-      sym_amount,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(204), 1,
-      sym_commodity,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5249] = 9,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(562), 1,
-      anon_sym_DASH,
-    ACTIONS(564), 1,
-      anon_sym_PLUS,
-    STATE(105), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(184), 1,
-      sym_quantity,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(457), 1,
-      sym_amount,
-    ACTIONS(523), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5280] = 9,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(562), 1,
-      anon_sym_DASH,
-    ACTIONS(564), 1,
-      anon_sym_PLUS,
-    STATE(120), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(184), 1,
-      sym_quantity,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(450), 1,
-      sym_amount,
-    ACTIONS(592), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5311] = 9,
-    ACTIONS(493), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      anon_sym_PLUS,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(103), 1,
-      sym_quantity,
-    STATE(125), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(220), 1,
-      sym_commodity,
-    STATE(304), 1,
-      sym_amount,
-    ACTIONS(594), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5342] = 9,
-    ACTIONS(596), 1,
-      sym_comment,
-    ACTIONS(600), 1,
-      anon_sym_alias,
-    ACTIONS(602), 1,
-      anon_sym_default,
-    ACTIONS(604), 1,
-      anon_sym_note,
-    ACTIONS(606), 1,
-      anon_sym_assert,
-    ACTIONS(608), 1,
-      anon_sym_check,
-    STATE(10), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(301), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(598), 2,
-      anon_sym_eval,
-      anon_sym_payee,
-  [5372] = 10,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(515), 1,
-      anon_sym_LF,
-    STATE(146), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(186), 1,
+      sym_lot_price,
+    STATE(163), 1,
       sym_price,
     STATE(235), 1,
       sym_balance_assertion,
-    STATE(456), 1,
+    STATE(459), 1,
       sym_note,
-    ACTIONS(610), 2,
+    ACTIONS(559), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5404] = 10,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(546), 1,
-      anon_sym_LF,
-    STATE(148), 1,
+  [4355] = 9,
+    ACTIONS(61), 1,
+      sym__2d,
+    ACTIONS(561), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(563), 1,
+      sym__month,
+    STATE(145), 1,
       aux_sym_whitespace_repeat1,
-    STATE(167), 1,
-      sym_price,
-    STATE(237), 1,
-      sym_balance_assertion,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(612), 2,
+    STATE(282), 1,
+      sym__4d,
+    STATE(393), 1,
+      sym_date_spec,
+    ACTIONS(567), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5436] = 10,
-    ACTIONS(495), 1,
+    STATE(343), 2,
+      sym__relative_date_spec,
+      sym__single_date,
+    ACTIONS(565), 3,
+      anon_sym_last,
+      anon_sym_this,
+      anon_sym_next,
+  [4387] = 7,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(400), 1,
+      sym__relative_date_spec,
+    STATE(404), 1,
+      sym__interval_date_spec,
+    ACTIONS(424), 2,
+      aux_sym__interval_date_spec_token1,
+      aux_sym__interval_date_spec_token2,
+    ACTIONS(569), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(426), 3,
+      aux_sym__interval_date_spec_token3,
+      aux_sym__interval_date_spec_token4,
+      aux_sym__interval_date_spec_token5,
+    ACTIONS(428), 3,
+      anon_sym_last,
+      anon_sym_this,
+      anon_sym_next,
+  [4415] = 9,
+    ACTIONS(61), 1,
+      sym__2d,
+    ACTIONS(561), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(563), 1,
+      sym__month,
+    STATE(145), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(281), 1,
+      sym_date_spec,
+    STATE(282), 1,
+      sym__4d,
+    ACTIONS(567), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(343), 2,
+      sym__relative_date_spec,
+      sym__single_date,
+    ACTIONS(565), 3,
+      anon_sym_last,
+      anon_sym_this,
+      anon_sym_next,
+  [4447] = 12,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    ACTIONS(540), 1,
-      anon_sym_LF,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(127), 1,
+      sym_lot_price,
+    STATE(159), 1,
+      sym_price,
+    STATE(225), 1,
+      sym_balance_assertion,
+    STATE(465), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [4485] = 12,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(135), 1,
+      sym_lot_price,
+    STATE(169), 1,
+      sym_price,
+    STATE(222), 1,
+      sym_balance_assertion,
+    STATE(460), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [4523] = 12,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(130), 1,
+      sym_lot_price,
+    STATE(163), 1,
+      sym_price,
+    STATE(235), 1,
+      sym_balance_assertion,
+    STATE(459), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [4561] = 12,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(490), 1,
+      anon_sym_LBRACE,
+    ACTIONS(492), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(131), 1,
+      sym_lot_price,
+    STATE(166), 1,
+      sym_price,
+    STATE(232), 1,
+      sym_balance_assertion,
+    STATE(437), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [4599] = 9,
+    ACTIONS(61), 1,
+      sym__2d,
+    ACTIONS(561), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(563), 1,
+      sym__month,
+    STATE(145), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(282), 1,
+      sym__4d,
+    STATE(396), 1,
+      sym_date_spec,
+    ACTIONS(567), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(343), 2,
+      sym__relative_date_spec,
+      sym__single_date,
+    ACTIONS(565), 3,
+      anon_sym_last,
+      anon_sym_this,
+      anon_sym_next,
+  [4631] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(297), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4662] = 9,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(573), 1,
+      anon_sym_DASH,
+    ACTIONS(575), 1,
+      anon_sym_PLUS,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(164), 1,
+      sym_quantity,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(469), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4693] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(299), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4724] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(301), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4755] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(284), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4786] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(112), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(326), 1,
+      sym_amount,
+    ACTIONS(577), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4817] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(116), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(254), 1,
+      sym_amount,
+    ACTIONS(579), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4848] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(114), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(327), 1,
+      sym_amount,
+    ACTIONS(581), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4879] = 9,
+    ACTIONS(478), 1,
+      anon_sym_DASH,
+    ACTIONS(484), 1,
+      anon_sym_PLUS,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(96), 1,
+      sym_quantity,
+    STATE(115), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(331), 1,
+      sym_amount,
+    ACTIONS(583), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4910] = 9,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(573), 1,
+      anon_sym_DASH,
+    ACTIONS(575), 1,
+      anon_sym_PLUS,
+    STATE(122), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(164), 1,
+      sym_quantity,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(439), 1,
+      sym_amount,
+    ACTIONS(585), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4941] = 9,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(573), 1,
+      anon_sym_DASH,
+    ACTIONS(575), 1,
+      anon_sym_PLUS,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(164), 1,
+      sym_quantity,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(420), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [4972] = 9,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(573), 1,
+      anon_sym_DASH,
+    ACTIONS(575), 1,
+      anon_sym_PLUS,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(164), 1,
+      sym_quantity,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(455), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [5003] = 9,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(573), 1,
+      anon_sym_DASH,
+    ACTIONS(575), 1,
+      anon_sym_PLUS,
+    STATE(97), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(164), 1,
+      sym_quantity,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(415), 1,
+      sym_amount,
+    ACTIONS(508), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [5034] = 11,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(595), 1,
+      anon_sym_SPACE,
+    ACTIONS(597), 1,
+      anon_sym_TAB,
     STATE(151), 1,
       aux_sym_whitespace_repeat1,
-    STATE(171), 1,
-      sym_price,
-    STATE(238), 1,
-      sym_balance_assertion,
-    STATE(469), 1,
+    STATE(207), 1,
+      sym_status,
+    STATE(259), 1,
+      sym_account,
+    STATE(475), 1,
       sym_note,
-    ACTIONS(614), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [5468] = 10,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(616), 1,
-      anon_sym_LF,
-    STATE(149), 1,
+    ACTIONS(587), 2,
+      anon_sym_STAR,
+      anon_sym_BANG,
+  [5069] = 9,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(573), 1,
+      anon_sym_DASH,
+    ACTIONS(575), 1,
+      anon_sym_PLUS,
+    STATE(124), 1,
       aux_sym_whitespace_repeat1,
-    STATE(179), 1,
-      sym_price,
-    STATE(242), 1,
-      sym_balance_assertion,
-    STATE(453), 1,
-      sym_note,
-    ACTIONS(618), 2,
+    STATE(164), 1,
+      sym_quantity,
+    STATE(203), 1,
+      sym_commodity,
+    STATE(420), 1,
+      sym_amount,
+    ACTIONS(599), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5500] = 10,
-    ACTIONS(495), 1,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [5100] = 10,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    ACTIONS(620), 1,
+    ACTIONS(557), 1,
       anon_sym_LF,
-    STATE(150), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(176), 1,
-      sym_price,
-    STATE(241), 1,
-      sym_balance_assertion,
-    STATE(432), 1,
-      sym_note,
-    ACTIONS(622), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [5532] = 2,
-    ACTIONS(202), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(200), 8,
-      anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [5548] = 2,
-    ACTIONS(405), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(403), 8,
-      anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [5564] = 2,
-    ACTIONS(208), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_AT,
-    ACTIONS(206), 8,
-      anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [5580] = 10,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    ACTIONS(519), 1,
-      anon_sym_LF,
-    STATE(147), 1,
+    STATE(140), 1,
       aux_sym_whitespace_repeat1,
     STATE(163), 1,
       sym_price,
-    STATE(236), 1,
+    STATE(235), 1,
       sym_balance_assertion,
-    STATE(490), 1,
+    STATE(459), 1,
       sym_note,
-    ACTIONS(624), 2,
+    ACTIONS(601), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5612] = 2,
-    ACTIONS(401), 3,
+  [5132] = 2,
+    ACTIONS(524), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_AT,
-    ACTIONS(399), 8,
+    ACTIONS(522), 8,
       anon_sym_LF,
       anon_sym_EQ,
       anon_sym_SEMI,
@@ -11479,332 +10877,441 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT_AT,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5628] = 9,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
-      anon_sym_AT_AT,
-    STATE(98), 1,
+  [5148] = 9,
+    ACTIONS(603), 1,
+      sym_comment,
+    ACTIONS(607), 1,
+      anon_sym_alias,
+    ACTIONS(609), 1,
+      anon_sym_default,
+    ACTIONS(611), 1,
+      anon_sym_note,
+    ACTIONS(613), 1,
+      anon_sym_assert,
+    ACTIONS(615), 1,
+      anon_sym_check,
+    STATE(10), 1,
       aux_sym_whitespace_repeat1,
-    STATE(163), 1,
-      sym_price,
-    STATE(236), 1,
-      sym_balance_assertion,
-    STATE(490), 1,
-      sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(430), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5657] = 9,
-    ACTIONS(495), 1,
+    ACTIONS(605), 2,
+      anon_sym_eval,
+      anon_sym_payee,
+  [5178] = 10,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    ACTIONS(553), 1,
+      anon_sym_LF,
+    STATE(141), 1,
       aux_sym_whitespace_repeat1,
-    STATE(167), 1,
+    STATE(166), 1,
       sym_price,
-    STATE(237), 1,
+    STATE(232), 1,
       sym_balance_assertion,
-    STATE(478), 1,
+    STATE(437), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(617), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5686] = 9,
-    ACTIONS(495), 1,
+  [5210] = 10,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    ACTIONS(619), 1,
+      anon_sym_LF,
+    STATE(143), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(169), 1,
+      sym_price,
+    STATE(222), 1,
+      sym_balance_assertion,
+    STATE(460), 1,
+      sym_note,
+    ACTIONS(621), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5242] = 10,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    ACTIONS(500), 1,
+      anon_sym_LF,
+    STATE(139), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(178), 1,
+      sym_price,
+    STATE(230), 1,
+      sym_balance_assertion,
+    STATE(448), 1,
+      sym_note,
+    ACTIONS(623), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5274] = 2,
+    ACTIONS(627), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(625), 8,
+      anon_sym_LF,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+      anon_sym_AT_AT,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5290] = 2,
+    ACTIONS(530), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(528), 8,
+      anon_sym_LF,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+      anon_sym_AT_AT,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5306] = 10,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    ACTIONS(629), 1,
+      anon_sym_LF,
+    STATE(142), 1,
       aux_sym_whitespace_repeat1,
     STATE(171), 1,
       sym_price,
-    STATE(238), 1,
+    STATE(236), 1,
       sym_balance_assertion,
-    STATE(469), 1,
+    STATE(410), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(631), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5715] = 9,
-    ACTIONS(495), 1,
+  [5338] = 10,
+    ACTIONS(476), 1,
+      anon_sym_LF,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    STATE(138), 1,
       aux_sym_whitespace_repeat1,
-    STATE(181), 1,
+    STATE(159), 1,
       sym_price,
-    STATE(243), 1,
+    STATE(225), 1,
       sym_balance_assertion,
-    STATE(482), 1,
+    STATE(465), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(633), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5744] = 9,
-    ACTIONS(495), 1,
+  [5370] = 2,
+    ACTIONS(637), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+    ACTIONS(635), 8,
+      anon_sym_LF,
       anon_sym_EQ,
-    ACTIONS(497), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
-      anon_sym_AT,
-    ACTIONS(511), 1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
       anon_sym_AT_AT,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(179), 1,
-      sym_price,
-    STATE(242), 1,
-      sym_balance_assertion,
-    STATE(453), 1,
-      sym_note,
-    ACTIONS(558), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5773] = 9,
-    ACTIONS(495), 1,
+  [5386] = 9,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(509), 1,
+    ACTIONS(494), 1,
       anon_sym_AT,
-    ACTIONS(511), 1,
+    ACTIONS(496), 1,
       anon_sym_AT_AT,
-    STATE(98), 1,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(176), 1,
+    STATE(163), 1,
       sym_price,
-    STATE(241), 1,
+    STATE(235), 1,
       sym_balance_assertion,
-    STATE(432), 1,
+    STATE(459), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5802] = 4,
-    ACTIONS(185), 1,
+  [5415] = 9,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(159), 1,
+      sym_price,
+    STATE(225), 1,
+      sym_balance_assertion,
+    STATE(465), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5444] = 9,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(166), 1,
+      sym_price,
+    STATE(232), 1,
+      sym_balance_assertion,
+    STATE(437), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5473] = 9,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(169), 1,
+      sym_price,
+    STATE(222), 1,
+      sym_balance_assertion,
+    STATE(460), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5502] = 9,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(172), 1,
+      sym_price,
+    STATE(213), 1,
+      sym_balance_assertion,
+    STATE(417), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5531] = 9,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(494), 1,
+      anon_sym_AT,
+    ACTIONS(496), 1,
+      anon_sym_AT_AT,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(171), 1,
+      sym_price,
+    STATE(236), 1,
+      sym_balance_assertion,
+    STATE(410), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5560] = 6,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(93), 1,
+      sym_negative_quantity,
+    STATE(195), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(251), 1,
+      sym_commodity,
+    ACTIONS(641), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [5582] = 4,
+    ACTIONS(190), 1,
       aux_sym_word_directive_token2,
-    STATE(152), 1,
+    STATE(145), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(626), 2,
+    ACTIONS(643), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(227), 5,
+    ACTIONS(510), 5,
       sym__month,
       anon_sym_last,
       anon_sym_this,
       anon_sym_next,
       sym__2d,
-  [5820] = 6,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(104), 1,
-      sym_negative_quantity,
-    STATE(192), 1,
+  [5600] = 3,
+    STATE(149), 1,
       aux_sym_whitespace_repeat1,
-    STATE(279), 1,
-      sym_commodity,
-    ACTIONS(631), 2,
+    ACTIONS(648), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+    ACTIONS(646), 6,
+      anon_sym_year,
+      sym__month,
+      anon_sym_day,
+      anon_sym_week,
+      anon_sym_month,
+      anon_sym_quarter,
+  [5616] = 6,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(167), 1,
+      sym_negative_quantity,
+    STATE(195), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(251), 1,
+      sym_commodity,
+    ACTIONS(641), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [5842] = 8,
-    ACTIONS(600), 1,
+  [5638] = 8,
+    ACTIONS(607), 1,
       anon_sym_alias,
-    ACTIONS(602), 1,
+    ACTIONS(609), 1,
       anon_sym_default,
-    ACTIONS(604), 1,
+    ACTIONS(611), 1,
       anon_sym_note,
-    ACTIONS(633), 1,
+    ACTIONS(650), 1,
       sym_comment,
-    ACTIONS(635), 1,
+    ACTIONS(652), 1,
       anon_sym_nomarket,
-    ACTIONS(637), 1,
+    ACTIONS(654), 1,
       anon_sym_format,
     STATE(10), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(301), 2,
+    ACTIONS(430), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [5868] = 5,
-    ACTIONS(185), 1,
-      anon_sym_SEMI,
-    ACTIONS(639), 1,
-      anon_sym_SPACE,
-    ACTIONS(642), 1,
-      anon_sym_TAB,
-    STATE(155), 1,
+  [5664] = 3,
+    STATE(149), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(227), 5,
+    ACTIONS(656), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(510), 6,
+      anon_sym_year,
+      sym__month,
+      anon_sym_day,
+      anon_sym_week,
+      anon_sym_month,
+      anon_sym_quarter,
+  [5680] = 7,
+    ACTIONS(661), 1,
+      anon_sym_LPAREN,
+    ACTIONS(663), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(221), 1,
+      sym_status,
+    STATE(231), 1,
+      sym_code,
+    ACTIONS(659), 2,
+      anon_sym_STAR,
+      anon_sym_BANG,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5704] = 5,
+    ACTIONS(190), 1,
+      anon_sym_SEMI,
+    ACTIONS(667), 1,
+      anon_sym_SPACE,
+    ACTIONS(670), 1,
+      anon_sym_TAB,
+    STATE(151), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(510), 5,
       anon_sym_STAR,
       anon_sym_BANG,
       anon_sym_LPAREN,
       anon_sym_LBRACK,
       sym_account_name,
-  [5888] = 3,
-    STATE(157), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(647), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(645), 6,
-      anon_sym_year,
-      sym__month,
-      anon_sym_day,
-      anon_sym_week,
-      anon_sym_month,
-      anon_sym_quarter,
-  [5904] = 3,
-    STATE(157), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(649), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(227), 6,
-      anon_sym_year,
-      sym__month,
-      anon_sym_day,
-      anon_sym_week,
-      anon_sym_month,
-      anon_sym_quarter,
-  [5920] = 6,
-    ACTIONS(652), 1,
-      sym__quantity,
-    STATE(12), 1,
-      sym_negative_quantity,
-    STATE(223), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(286), 1,
-      sym_commodity,
-    ACTIONS(654), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5942] = 6,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(168), 1,
-      sym_negative_quantity,
-    STATE(192), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(279), 1,
-      sym_commodity,
-    ACTIONS(631), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [5964] = 7,
-    ACTIONS(658), 1,
-      anon_sym_LPAREN,
-    ACTIONS(660), 1,
-      sym_payee,
-    STATE(216), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(227), 1,
-      sym_status,
-    STATE(228), 1,
-      sym_code,
-    ACTIONS(656), 2,
-      anon_sym_STAR,
-      anon_sym_BANG,
-    ACTIONS(662), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [5988] = 7,
-    ACTIONS(457), 1,
+  [5724] = 7,
+    ACTIONS(673), 1,
+      anon_sym_LF,
+    ACTIONS(675), 1,
+      aux_sym_block_comment_token1,
+    ACTIONS(677), 1,
+      anon_sym_end,
+    ACTIONS(679), 1,
       anon_sym_endcomment,
-    ACTIONS(664), 1,
-      anon_sym_LF,
-    ACTIONS(666), 1,
-      aux_sym_block_comment_token1,
-    ACTIONS(668), 1,
-      anon_sym_end,
-    STATE(166), 1,
+    STATE(161), 1,
       aux_sym_block_comment_repeat1,
-    STATE(357), 1,
+    STATE(324), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(670), 2,
+    ACTIONS(681), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6011] = 7,
-    ACTIONS(433), 1,
-      anon_sym_endtest,
-    ACTIONS(672), 1,
-      anon_sym_LF,
-    ACTIONS(674), 1,
-      aux_sym_block_comment_token1,
-    ACTIONS(676), 1,
-      anon_sym_end,
-    STATE(169), 1,
-      aux_sym_block_comment_repeat1,
-    STATE(363), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(678), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6034] = 7,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(546), 1,
-      anon_sym_LF,
-    STATE(212), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(237), 1,
-      sym_balance_assertion,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(680), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6057] = 7,
-    ACTIONS(666), 1,
-      aux_sym_block_comment_token1,
-    ACTIONS(682), 1,
-      anon_sym_LF,
-    ACTIONS(684), 1,
-      anon_sym_end,
-    ACTIONS(686), 1,
-      anon_sym_endcomment,
-    STATE(187), 1,
-      aux_sym_block_comment_repeat1,
-    STATE(357), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(670), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6080] = 2,
-    ACTIONS(690), 1,
+  [5747] = 2,
+    ACTIONS(685), 1,
       sym__dsep,
-    ACTIONS(688), 7,
+    ACTIONS(683), 7,
       anon_sym_LF,
       anon_sym_EQ,
       sym_time,
@@ -11812,703 +11319,480 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6093] = 7,
-    ACTIONS(421), 1,
-      anon_sym_endcomment,
-    ACTIONS(666), 1,
-      aux_sym_block_comment_token1,
-    ACTIONS(692), 1,
-      anon_sym_LF,
-    ACTIONS(694), 1,
-      anon_sym_end,
-    STATE(188), 1,
-      aux_sym_block_comment_repeat1,
-    STATE(357), 1,
+  [5760] = 7,
+    ACTIONS(37), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(61), 1,
+      sym__2d,
+    STATE(168), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(670), 2,
+    STATE(239), 1,
+      sym__single_date,
+    STATE(314), 1,
+      sym_date,
+    STATE(441), 1,
+      sym__4d,
+    ACTIONS(687), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6116] = 7,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(540), 1,
-      anon_sym_LF,
-    STATE(198), 1,
+  [5783] = 7,
+    ACTIONS(37), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(61), 1,
+      sym__2d,
+    STATE(170), 1,
       aux_sym_whitespace_repeat1,
-    STATE(238), 1,
-      sym_balance_assertion,
-    STATE(469), 1,
-      sym_note,
-    ACTIONS(696), 2,
+    STATE(239), 1,
+      sym__single_date,
+    STATE(318), 1,
+      sym_date,
+    STATE(441), 1,
+      sym__4d,
+    ACTIONS(689), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6139] = 5,
-    ACTIONS(200), 1,
-      anon_sym_LF,
-    STATE(143), 1,
-      sym_commodity,
-    STATE(180), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(698), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [6158] = 7,
-    ACTIONS(427), 1,
+  [5806] = 7,
+    ACTIONS(436), 1,
       anon_sym_endtest,
-    ACTIONS(674), 1,
+    ACTIONS(691), 1,
+      anon_sym_LF,
+    ACTIONS(693), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(700), 1,
+    ACTIONS(695), 1,
+      anon_sym_end,
+    STATE(174), 1,
+      aux_sym_block_comment_repeat1,
+    STATE(338), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(697), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5829] = 6,
+    ACTIONS(699), 1,
       anon_sym_LF,
     ACTIONS(702), 1,
-      anon_sym_end,
-    STATE(185), 1,
-      aux_sym_block_comment_repeat1,
-    STATE(363), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(678), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6181] = 7,
-    ACTIONS(451), 1,
-      anon_sym_endtest,
-    ACTIONS(674), 1,
       aux_sym_block_comment_token1,
-    ACTIONS(700), 1,
-      anon_sym_LF,
-    ACTIONS(704), 1,
-      anon_sym_end,
-    STATE(185), 1,
+    STATE(157), 1,
       aux_sym_block_comment_repeat1,
-    STATE(363), 1,
+    STATE(324), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(678), 2,
+    ACTIONS(705), 2,
+      anon_sym_end,
+      anon_sym_endcomment,
+    ACTIONS(707), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6204] = 7,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(620), 1,
+  [5850] = 7,
+    ACTIONS(402), 1,
+      anon_sym_endcomment,
+    ACTIONS(675), 1,
+      aux_sym_block_comment_token1,
+    ACTIONS(710), 1,
       anon_sym_LF,
-    STATE(189), 1,
+    ACTIONS(712), 1,
+      anon_sym_end,
+    STATE(173), 1,
+      aux_sym_block_comment_repeat1,
+    STATE(324), 1,
       aux_sym_whitespace_repeat1,
-    STATE(241), 1,
-      sym_balance_assertion,
-    STATE(432), 1,
-      sym_note,
-    ACTIONS(706), 2,
+    ACTIONS(681), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6227] = 7,
-    ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(59), 1,
-      sym__2d,
-    STATE(182), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(232), 1,
-      sym__single_date,
-    STATE(333), 1,
-      sym_date,
-    STATE(443), 1,
-      sym__4d,
-    ACTIONS(708), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6250] = 7,
-    ACTIONS(495), 1,
+  [5873] = 7,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(515), 1,
+    ACTIONS(557), 1,
       anon_sym_LF,
-    STATE(222), 1,
+    STATE(186), 1,
       aux_sym_whitespace_repeat1,
     STATE(235), 1,
       sym_balance_assertion,
-    STATE(456), 1,
-      sym_note,
-    ACTIONS(710), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6273] = 5,
-    ACTIONS(200), 1,
-      anon_sym_LF,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(143), 1,
-      sym_commodity,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [6292] = 7,
-    ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(59), 1,
-      sym__2d,
-    STATE(183), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(232), 1,
-      sym__single_date,
-    STATE(334), 1,
-      sym_date,
-    STATE(443), 1,
-      sym__4d,
-    ACTIONS(712), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6315] = 7,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(616), 1,
-      anon_sym_LF,
-    STATE(194), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(242), 1,
-      sym_balance_assertion,
-    STATE(453), 1,
+    STATE(459), 1,
       sym_note,
     ACTIONS(714), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6338] = 7,
-    ACTIONS(674), 1,
+  [5896] = 5,
+    ACTIONS(528), 1,
+      anon_sym_LF,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(133), 1,
+      sym_commodity,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [5915] = 7,
+    ACTIONS(414), 1,
+      anon_sym_endcomment,
+    ACTIONS(675), 1,
       aux_sym_block_comment_token1,
     ACTIONS(716), 1,
       anon_sym_LF,
     ACTIONS(718), 1,
       anon_sym_end,
-    ACTIONS(720), 1,
-      anon_sym_endtest,
-    STATE(170), 1,
+    STATE(157), 1,
       aux_sym_block_comment_repeat1,
-    STATE(363), 1,
+    STATE(324), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(678), 2,
+    ACTIONS(681), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6361] = 7,
-    ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(59), 1,
-      sym__2d,
-    STATE(98), 1,
+  [5938] = 7,
+    ACTIONS(420), 1,
+      anon_sym_endtest,
+    ACTIONS(693), 1,
+      aux_sym_block_comment_token1,
+    ACTIONS(720), 1,
+      anon_sym_LF,
+    ACTIONS(722), 1,
+      anon_sym_end,
+    STATE(179), 1,
+      aux_sym_block_comment_repeat1,
+    STATE(338), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(697), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [5961] = 7,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(553), 1,
+      anon_sym_LF,
+    STATE(190), 1,
       aux_sym_whitespace_repeat1,
     STATE(232), 1,
-      sym__single_date,
-    STATE(401), 1,
-      sym_date,
-    STATE(443), 1,
-      sym__4d,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6384] = 7,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(722), 1,
-      anon_sym_LF,
-    STATE(197), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(243), 1,
       sym_balance_assertion,
-    STATE(482), 1,
+    STATE(437), 1,
       sym_note,
     ACTIONS(724), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6407] = 5,
-    ACTIONS(206), 1,
+  [5984] = 5,
+    ACTIONS(532), 1,
       anon_sym_LF,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(145), 1,
+    STATE(128), 1,
       sym_commodity,
-    ACTIONS(558), 2,
+    STATE(177), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(726), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [6426] = 7,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(726), 1,
-      anon_sym_LF,
-    STATE(200), 1,
+  [6003] = 7,
+    ACTIONS(37), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(61), 1,
+      sym__2d,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(244), 1,
+    STATE(239), 1,
+      sym__single_date,
+    STATE(388), 1,
+      sym_date,
+    STATE(441), 1,
+      sym__4d,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6026] = 7,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(619), 1,
+      anon_sym_LF,
+    STATE(193), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(222), 1,
       sym_balance_assertion,
-    STATE(438), 1,
+    STATE(460), 1,
       sym_note,
     ACTIONS(728), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6449] = 7,
-    ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(59), 1,
-      sym__2d,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(232), 1,
-      sym__single_date,
-    STATE(316), 1,
-      sym_date,
-    STATE(443), 1,
-      sym__4d,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6472] = 7,
-    ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(59), 1,
-      sym__2d,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(232), 1,
-      sym__single_date,
-    STATE(326), 1,
-      sym_date,
-    STATE(443), 1,
-      sym__4d,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6495] = 5,
-    ACTIONS(190), 1,
+  [6049] = 5,
+    ACTIONS(522), 1,
       anon_sym_LF,
-    STATE(141), 1,
+    STATE(134), 1,
       sym_commodity,
-    STATE(174), 1,
+    STATE(160), 1,
       aux_sym_whitespace_repeat1,
     ACTIONS(730), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [6514] = 6,
-    ACTIONS(732), 1,
-      anon_sym_LF,
-    ACTIONS(735), 1,
-      aux_sym_block_comment_token1,
-    STATE(185), 1,
-      aux_sym_block_comment_repeat1,
-    STATE(363), 1,
+  [6068] = 7,
+    ACTIONS(37), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(61), 1,
+      sym__2d,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(738), 2,
-      anon_sym_end,
-      anon_sym_endtest,
-    ACTIONS(740), 2,
+    STATE(239), 1,
+      sym__single_date,
+    STATE(308), 1,
+      sym_date,
+    STATE(441), 1,
+      sym__4d,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6535] = 7,
-    ACTIONS(495), 1,
+  [6091] = 7,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(519), 1,
+    ACTIONS(629), 1,
       anon_sym_LF,
-    STATE(203), 1,
+    STATE(197), 1,
       aux_sym_whitespace_repeat1,
     STATE(236), 1,
       sym_balance_assertion,
-    STATE(490), 1,
+    STATE(410), 1,
       sym_note,
-    ACTIONS(743), 2,
+    ACTIONS(732), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6558] = 7,
-    ACTIONS(415), 1,
-      anon_sym_endcomment,
-    ACTIONS(666), 1,
-      aux_sym_block_comment_token1,
-    ACTIONS(692), 1,
-      anon_sym_LF,
-    ACTIONS(745), 1,
-      anon_sym_end,
-    STATE(188), 1,
-      aux_sym_block_comment_repeat1,
-    STATE(357), 1,
+  [6114] = 7,
+    ACTIONS(37), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(61), 1,
+      sym__2d,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(670), 2,
+    STATE(239), 1,
+      sym__single_date,
+    STATE(315), 1,
+      sym_date,
+    STATE(441), 1,
+      sym__4d,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6581] = 6,
+  [6137] = 7,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(734), 1,
+      anon_sym_LF,
+    STATE(199), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(213), 1,
+      sym_balance_assertion,
+    STATE(417), 1,
+      sym_note,
+    ACTIONS(736), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6160] = 7,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(738), 1,
+      anon_sym_LF,
+    STATE(200), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(216), 1,
+      sym_balance_assertion,
+    STATE(423), 1,
+      sym_note,
+    ACTIONS(740), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6183] = 7,
+    ACTIONS(442), 1,
+      anon_sym_endcomment,
+    ACTIONS(675), 1,
+      aux_sym_block_comment_token1,
+    ACTIONS(716), 1,
+      anon_sym_LF,
+    ACTIONS(742), 1,
+      anon_sym_end,
+    STATE(157), 1,
+      aux_sym_block_comment_repeat1,
+    STATE(324), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(681), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6206] = 6,
+    ACTIONS(744), 1,
+      anon_sym_LF,
     ACTIONS(747), 1,
-      anon_sym_LF,
-    ACTIONS(750), 1,
       aux_sym_block_comment_token1,
-    STATE(188), 1,
+    STATE(174), 1,
       aux_sym_block_comment_repeat1,
-    STATE(357), 1,
+    STATE(338), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(738), 2,
+    ACTIONS(705), 2,
       anon_sym_end,
-      anon_sym_endcomment,
-    ACTIONS(753), 2,
+      anon_sym_endtest,
+    ACTIONS(750), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6602] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(242), 1,
-      sym_balance_assertion,
-    STATE(453), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6622] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(756), 1,
-      anon_sym_SPACE,
-    ACTIONS(758), 1,
-      anon_sym_TAB,
-    STATE(215), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(275), 1,
-      sym_account,
-  [6644] = 6,
-    ACTIONS(501), 1,
-      sym__quantity,
-    ACTIONS(760), 1,
-      anon_sym_DASH,
-    ACTIONS(762), 1,
-      anon_sym_PLUS,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(143), 1,
-      sym_quantity,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6664] = 4,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(294), 1,
-      sym_commodity,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [6680] = 2,
-    ACTIONS(766), 1,
-      anon_sym_AT,
-    ACTIONS(764), 6,
+  [6227] = 7,
+    ACTIONS(693), 1,
+      aux_sym_block_comment_token1,
+    ACTIONS(753), 1,
       anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6692] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
+    ACTIONS(755), 1,
+      anon_sym_end,
+    ACTIONS(757), 1,
+      anon_sym_endtest,
+    STATE(156), 1,
+      aux_sym_block_comment_repeat1,
+    STATE(338), 1,
       aux_sym_whitespace_repeat1,
-    STATE(243), 1,
-      sym_balance_assertion,
-    STATE(482), 1,
-      sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(697), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [6712] = 2,
-    ACTIONS(770), 1,
-      anon_sym_AT,
-    ACTIONS(768), 6,
+  [6250] = 3,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(759), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(190), 5,
+      anon_sym_STAR,
+      anon_sym_BANG,
+      anon_sym_LPAREN,
+      sym_payee,
+      anon_sym_SEMI,
+  [6265] = 5,
+    ACTIONS(522), 1,
       anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6724] = 4,
-    STATE(98), 1,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(457), 1,
+    STATE(134), 1,
       sym_commodity,
-    ACTIONS(558), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [6740] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(244), 1,
-      sym_balance_assertion,
-    STATE(438), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6760] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(241), 1,
-      sym_balance_assertion,
-    STATE(432), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6780] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(772), 1,
-      anon_sym_SPACE,
-    ACTIONS(774), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(472), 1,
-      sym_account,
-  [6802] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(245), 1,
-      sym_balance_assertion,
-    STATE(451), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6822] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(772), 1,
-      anon_sym_SPACE,
-    ACTIONS(774), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(457), 1,
-      sym_account,
-  [6844] = 6,
-    ACTIONS(776), 1,
-      aux_sym_note_token1,
-    ACTIONS(778), 1,
-      anon_sym_LBRACK,
-    ACTIONS(780), 1,
-      aux_sym_note_token2,
-    STATE(224), 1,
-      aux_sym_note_repeat1,
-    STATE(339), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(782), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6864] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(237), 1,
-      sym_balance_assertion,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6884] = 6,
-    ACTIONS(784), 1,
-      anon_sym_DASH,
-    ACTIONS(786), 1,
-      anon_sym_PLUS,
-    ACTIONS(788), 1,
-      sym__quantity,
-    STATE(61), 1,
-      sym_quantity,
-    STATE(209), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(790), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [6904] = 4,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(426), 1,
-      sym_commodity,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [6920] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(772), 1,
-      anon_sym_SPACE,
-    ACTIONS(774), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(277), 1,
-      sym_account,
-  [6942] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(772), 1,
-      anon_sym_SPACE,
-    ACTIONS(774), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(439), 1,
-      sym_account,
-  [6964] = 4,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(133), 1,
-      sym_commodity,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [6980] = 6,
-    ACTIONS(788), 1,
-      sym__quantity,
-    ACTIONS(792), 1,
-      anon_sym_DASH,
-    ACTIONS(794), 1,
-      anon_sym_PLUS,
-    STATE(62), 1,
-      sym_quantity,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7000] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(772), 1,
-      anon_sym_SPACE,
-    ACTIONS(774), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(258), 1,
-      sym_account,
-  [7022] = 2,
-    ACTIONS(798), 1,
-      anon_sym_AT,
-    ACTIONS(796), 6,
+  [6284] = 7,
+    ACTIONS(476), 1,
       anon_sym_LF,
+    ACTIONS(480), 1,
       anon_sym_EQ,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-      anon_sym_AT_AT,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7034] = 6,
-    ACTIONS(495), 1,
-      anon_sym_EQ,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(238), 1,
-      sym_balance_assertion,
-    STATE(469), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7054] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(800), 1,
-      anon_sym_SPACE,
-    ACTIONS(802), 1,
-      anon_sym_TAB,
     STATE(206), 1,
       aux_sym_whitespace_repeat1,
-    STATE(258), 1,
+    STATE(225), 1,
+      sym_balance_assertion,
+    STATE(465), 1,
+      sym_note,
+    ACTIONS(762), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6307] = 7,
+    ACTIONS(390), 1,
+      anon_sym_endtest,
+    ACTIONS(691), 1,
+      anon_sym_LF,
+    ACTIONS(693), 1,
+      aux_sym_block_comment_token1,
+    ACTIONS(764), 1,
+      anon_sym_end,
+    STATE(174), 1,
+      aux_sym_block_comment_repeat1,
+    STATE(338), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(697), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6330] = 7,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(500), 1,
+      anon_sym_LF,
+    STATE(194), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(230), 1,
+      sym_balance_assertion,
+    STATE(448), 1,
+      sym_note,
+    ACTIONS(766), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6353] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(768), 1,
+      anon_sym_SPACE,
+    ACTIONS(770), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(279), 1,
       sym_account,
-  [7076] = 1,
-    ACTIONS(804), 7,
+  [6375] = 4,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(469), 1,
+      sym_commodity,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [6391] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(772), 1,
+      anon_sym_SPACE,
+    ACTIONS(774), 1,
+      anon_sym_TAB,
+    STATE(204), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(245), 1,
+      sym_account,
+  [6413] = 4,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(289), 1,
+      sym_commodity,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [6429] = 1,
+    ACTIONS(776), 7,
       anon_sym_LF,
       anon_sym_EQ,
       sym_time,
@@ -12516,2428 +11800,2627 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7086] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(772), 1,
-      anon_sym_SPACE,
-    ACTIONS(774), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
+  [6439] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(266), 1,
+    STATE(232), 1,
+      sym_balance_assertion,
+    STATE(437), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6459] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(768), 1,
+      anon_sym_SPACE,
+    ACTIONS(770), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(248), 1,
       sym_account,
-  [7108] = 3,
+  [6481] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(768), 1,
+      anon_sym_SPACE,
+    ACTIONS(770), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(451), 1,
+      sym_account,
+  [6503] = 2,
+    ACTIONS(780), 1,
+      anon_sym_AT,
+    ACTIONS(778), 6,
+      anon_sym_LF,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      anon_sym_AT_AT,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6515] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(222), 1,
+      sym_balance_assertion,
+    STATE(460), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6535] = 4,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(452), 1,
+      sym_commodity,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [6551] = 2,
+    ACTIONS(784), 1,
+      anon_sym_AT,
+    ACTIONS(782), 6,
+      anon_sym_LF,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      anon_sym_AT_AT,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6563] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(236), 1,
+      sym_balance_assertion,
+    STATE(410), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6583] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(225), 1,
+      sym_balance_assertion,
+    STATE(465), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6603] = 4,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(275), 1,
+      sym_commodity,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
+      aux_sym_commodity_token1,
+      aux_sym_commodity_token2,
+      aux_sym_commodity_token3,
+  [6619] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(768), 1,
+      anon_sym_SPACE,
+    ACTIONS(770), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(476), 1,
+      sym_account,
+  [6641] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(213), 1,
+      sym_balance_assertion,
+    STATE(417), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6661] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(768), 1,
+      anon_sym_SPACE,
+    ACTIONS(770), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(469), 1,
+      sym_account,
+  [6683] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
     STATE(216), 1,
+      sym_balance_assertion,
+    STATE(423), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6703] = 6,
+    ACTIONS(480), 1,
+      anon_sym_EQ,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(219), 1,
+      sym_balance_assertion,
+    STATE(428), 1,
+      sym_note,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6723] = 6,
+    ACTIONS(786), 1,
+      aux_sym_note_token1,
+    ACTIONS(788), 1,
+      anon_sym_LBRACK,
+    ACTIONS(790), 1,
+      aux_sym_note_token2,
+    STATE(202), 1,
+      aux_sym_note_repeat1,
+    STATE(330), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(792), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6743] = 6,
+    ACTIONS(794), 1,
+      aux_sym_note_token1,
+    ACTIONS(796), 1,
+      anon_sym_LBRACK,
+    ACTIONS(798), 1,
+      aux_sym_note_token2,
+    STATE(226), 1,
+      aux_sym_note_repeat1,
+    STATE(335), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(800), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6763] = 6,
+    ACTIONS(486), 1,
+      sym__quantity,
+    ACTIONS(802), 1,
+      anon_sym_DASH,
+    ACTIONS(804), 1,
+      anon_sym_PLUS,
+    STATE(128), 1,
+      sym_quantity,
+    STATE(205), 1,
       aux_sym_whitespace_repeat1,
     ACTIONS(806), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(185), 4,
-      anon_sym_STAR,
-      anon_sym_BANG,
+  [6783] = 7,
+    ACTIONS(589), 1,
       anon_sym_LPAREN,
-      sym_payee,
-  [7122] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
+    ACTIONS(591), 1,
       anon_sym_LBRACK,
-    ACTIONS(572), 1,
+    ACTIONS(593), 1,
       sym_account_name,
-    ACTIONS(772), 1,
+    ACTIONS(768), 1,
       anon_sym_SPACE,
-    ACTIONS(774), 1,
+    ACTIONS(770), 1,
       anon_sym_TAB,
-    STATE(250), 1,
+    STATE(229), 1,
       aux_sym_whitespace_repeat1,
-    STATE(296), 1,
+    STATE(240), 1,
       sym_account,
-  [7144] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(809), 1,
-      anon_sym_SPACE,
-    ACTIONS(811), 1,
-      anon_sym_TAB,
-    STATE(210), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(296), 1,
-      sym_account,
-  [7166] = 4,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(306), 1,
-      sym_commodity,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(503), 3,
-      aux_sym_commodity_token1,
-      aux_sym_commodity_token2,
-      aux_sym_commodity_token3,
-  [7182] = 6,
-    ACTIONS(501), 1,
+  [6805] = 6,
+    ACTIONS(486), 1,
       sym__quantity,
-    ACTIONS(813), 1,
+    ACTIONS(808), 1,
       anon_sym_DASH,
-    ACTIONS(815), 1,
+    ACTIONS(810), 1,
       anon_sym_PLUS,
-    STATE(141), 1,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(134), 1,
       sym_quantity,
-    STATE(191), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(817), 2,
+    ACTIONS(569), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7202] = 7,
-    ACTIONS(568), 1,
-      anon_sym_LPAREN,
-    ACTIONS(570), 1,
-      anon_sym_LBRACK,
-    ACTIONS(572), 1,
-      sym_account_name,
-    ACTIONS(819), 1,
-      anon_sym_SPACE,
-    ACTIONS(821), 1,
-      anon_sym_TAB,
-    STATE(217), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(288), 1,
-      sym_account,
-  [7224] = 6,
-    ACTIONS(495), 1,
+  [6825] = 6,
+    ACTIONS(480), 1,
       anon_sym_EQ,
-    ACTIONS(497), 1,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    STATE(98), 1,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    STATE(236), 1,
+    STATE(235), 1,
       sym_balance_assertion,
-    STATE(490), 1,
+    STATE(459), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7244] = 4,
-    STATE(98), 1,
+  [6845] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(812), 1,
+      anon_sym_SPACE,
+    ACTIONS(814), 1,
+      anon_sym_TAB,
+    STATE(187), 1,
       aux_sym_whitespace_repeat1,
-    STATE(291), 1,
-      sym_commodity,
-    ACTIONS(558), 2,
+    STATE(283), 1,
+      sym_account,
+  [6867] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(768), 1,
+      anon_sym_SPACE,
+    ACTIONS(770), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(245), 1,
+      sym_account,
+  [6889] = 2,
+    ACTIONS(818), 1,
+      anon_sym_AT,
+    ACTIONS(816), 6,
+      anon_sym_LF,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      anon_sym_AT_AT,
       anon_sym_SPACE,
       anon_sym_TAB,
-    ACTIONS(503), 3,
+  [6901] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
+      anon_sym_LBRACK,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(820), 1,
+      anon_sym_SPACE,
+    ACTIONS(822), 1,
+      anon_sym_TAB,
+    STATE(181), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(253), 1,
+      sym_account,
+  [6923] = 4,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(126), 1,
+      sym_commodity,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    ACTIONS(488), 3,
       aux_sym_commodity_token1,
       aux_sym_commodity_token2,
       aux_sym_commodity_token3,
-  [7260] = 6,
-    ACTIONS(823), 1,
-      aux_sym_note_token1,
-    ACTIONS(825), 1,
+  [6939] = 7,
+    ACTIONS(589), 1,
+      anon_sym_LPAREN,
+    ACTIONS(591), 1,
       anon_sym_LBRACK,
-    ACTIONS(827), 1,
-      aux_sym_note_token2,
-    STATE(248), 1,
-      aux_sym_note_repeat1,
-    STATE(343), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(829), 2,
+    ACTIONS(593), 1,
+      sym_account_name,
+    ACTIONS(824), 1,
       anon_sym_SPACE,
+    ACTIONS(826), 1,
       anon_sym_TAB,
-  [7280] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(515), 1,
-      anon_sym_LF,
-    STATE(293), 1,
+    STATE(208), 1,
       aux_sym_whitespace_repeat1,
-    STATE(456), 1,
+    STATE(279), 1,
+      sym_account,
+  [6961] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(738), 1,
+      anon_sym_LF,
+    STATE(272), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(423), 1,
       sym_note,
-    ACTIONS(831), 2,
+    ACTIONS(828), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7297] = 6,
-    ACTIONS(829), 1,
+  [6978] = 5,
+    ACTIONS(607), 1,
+      anon_sym_alias,
+    ACTIONS(830), 1,
+      sym_comment,
+    ACTIONS(832), 1,
+      anon_sym_uuid,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(569), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [6995] = 2,
+    ACTIONS(834), 1,
       anon_sym_LF,
-    ACTIONS(833), 1,
+    ACTIONS(836), 5,
+      aux_sym_block_comment_token1,
+      anon_sym_end,
+      anon_sym_endcomment,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7006] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(838), 1,
+      anon_sym_LF,
+    STATE(274), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(428), 1,
+      sym_note,
+    ACTIONS(840), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7023] = 2,
+    ACTIONS(842), 1,
+      anon_sym_LF,
+    ACTIONS(705), 5,
+      aux_sym_block_comment_token1,
+      anon_sym_end,
+      anon_sym_endcomment,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7034] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(500), 1,
+      anon_sym_LF,
+    STATE(255), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(448), 1,
+      sym_note,
+    ACTIONS(844), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7051] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(846), 1,
+      anon_sym_LF,
+    STATE(277), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(432), 1,
+      sym_note,
+    ACTIONS(848), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7068] = 6,
+    ACTIONS(792), 1,
+      anon_sym_LF,
+    ACTIONS(850), 1,
       aux_sym_note_token1,
-    ACTIONS(835), 1,
+    ACTIONS(852), 1,
       anon_sym_LBRACK,
-    ACTIONS(837), 1,
+    ACTIONS(854), 1,
+      aux_sym_note_token2,
+    STATE(224), 1,
+      aux_sym_note_repeat1,
+    STATE(352), 1,
+      aux_sym_note_repeat2,
+  [7087] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(856), 1,
+      anon_sym_LF,
+    STATE(228), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(474), 1,
+      sym_note,
+    ACTIONS(858), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7104] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(629), 1,
+      anon_sym_LF,
+    STATE(270), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(410), 1,
+      sym_note,
+    ACTIONS(860), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7121] = 2,
+    ACTIONS(842), 1,
+      anon_sym_LF,
+    ACTIONS(705), 5,
+      aux_sym_block_comment_token1,
+      anon_sym_end,
+      anon_sym_endtest,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7132] = 6,
+    ACTIONS(800), 1,
+      anon_sym_LF,
+    ACTIONS(862), 1,
+      aux_sym_note_token1,
+    ACTIONS(864), 1,
+      anon_sym_LBRACK,
+    ACTIONS(866), 1,
       aux_sym_note_token2,
     STATE(261), 1,
       aux_sym_note_repeat1,
-    STATE(367), 1,
+    STATE(358), 1,
       aux_sym_note_repeat2,
-  [7316] = 5,
-    ACTIONS(497), 1,
+  [7151] = 5,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(839), 1,
+    ACTIONS(557), 1,
       anon_sym_LF,
-    STATE(239), 1,
+    STATE(264), 1,
       aux_sym_whitespace_repeat1,
-    STATE(489), 1,
+    STATE(459), 1,
       sym_note,
-    ACTIONS(841), 2,
+    ACTIONS(868), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7333] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(839), 1,
-      anon_sym_LF,
-    STATE(332), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(489), 1,
-      sym_note,
-    ACTIONS(843), 2,
+  [7168] = 4,
+    ACTIONS(870), 1,
+      aux_sym_note_token1,
+    ACTIONS(875), 1,
+      aux_sym_note_token2,
+    STATE(226), 1,
+      aux_sym_note_repeat1,
+    ACTIONS(873), 3,
+      anon_sym_LBRACK,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7350] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(845), 1,
+  [7183] = 2,
+    ACTIONS(834), 1,
       anon_sym_LF,
-    STATE(341), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(433), 1,
-      sym_note,
-    ACTIONS(847), 2,
+    ACTIONS(836), 5,
+      aux_sym_block_comment_token1,
+      anon_sym_end,
+      anon_sym_endtest,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7367] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(849), 1,
-      anon_sym_LF,
-    STATE(160), 1,
+  [7194] = 5,
+    ACTIONS(661), 1,
+      anon_sym_LPAREN,
+    ACTIONS(877), 1,
+      sym_payee,
+    STATE(176), 1,
       aux_sym_whitespace_repeat1,
-    STATE(435), 1,
-      sym_note,
-    ACTIONS(851), 2,
+    STATE(238), 1,
+      sym_code,
+    ACTIONS(665), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7384] = 3,
-    ACTIONS(855), 1,
+  [7211] = 4,
+    ACTIONS(879), 1,
+      anon_sym_SPACE,
+    ACTIONS(882), 1,
+      anon_sym_TAB,
+    STATE(229), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(510), 3,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      sym_account_name,
+  [7226] = 5,
+    ACTIONS(476), 1,
+      anon_sym_LF,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(258), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(465), 1,
+      sym_note,
+    ACTIONS(885), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7243] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(856), 1,
+      anon_sym_LF,
+    STATE(309), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(474), 1,
+      sym_note,
+    ACTIONS(887), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7260] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(619), 1,
+      anon_sym_LF,
+    STATE(268), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(460), 1,
+      sym_note,
+    ACTIONS(889), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7277] = 3,
+    ACTIONS(893), 1,
       anon_sym_EQ,
-    STATE(345), 1,
+    STATE(332), 1,
       sym_effective_date,
-    ACTIONS(853), 4,
+    ACTIONS(891), 4,
       anon_sym_LF,
       anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7397] = 1,
-    ACTIONS(857), 6,
+  [7290] = 5,
+    ACTIONS(613), 1,
+      anon_sym_assert,
+    ACTIONS(615), 1,
+      anon_sym_check,
+    ACTIONS(895), 1,
+      sym_comment,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(569), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7307] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(553), 1,
+      anon_sym_LF,
+    STATE(266), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(437), 1,
+      sym_note,
+    ACTIONS(897), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7324] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(734), 1,
+      anon_sym_LF,
+    STATE(271), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(417), 1,
+      sym_note,
+    ACTIONS(899), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7341] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(901), 1,
+      anon_sym_LF,
+    STATE(150), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(436), 1,
+      sym_note,
+    ACTIONS(903), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7358] = 5,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(905), 1,
+      anon_sym_LF,
+    STATE(303), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(449), 1,
+      sym_note,
+    ACTIONS(907), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7375] = 1,
+    ACTIONS(909), 6,
       anon_sym_LF,
       anon_sym_EQ,
       sym_time,
       anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7406] = 2,
-    ACTIONS(859), 1,
+  [7384] = 2,
+    ACTIONS(911), 1,
       anon_sym_LF,
-    ACTIONS(738), 5,
-      aux_sym_block_comment_token1,
-      anon_sym_end,
-      anon_sym_endcomment,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7417] = 5,
-    ACTIONS(606), 1,
-      anon_sym_assert,
-    ACTIONS(608), 1,
-      anon_sym_check,
-    ACTIONS(861), 1,
-      sym_comment,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7434] = 5,
-    ACTIONS(497), 1,
+    ACTIONS(913), 4,
+      anon_sym_,
+      anon_sym_TAB2,
+      anon_sym_TAB3,
+      anon_sym_TAB_TAB,
+  [7394] = 1,
+    ACTIONS(915), 5,
+      anon_sym_LF,
       anon_sym_SEMI,
-    ACTIONS(519), 1,
-      anon_sym_LF,
-    STATE(254), 1,
+      anon_sym_RBRACK,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7402] = 3,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    STATE(490), 1,
-      sym_note,
-    ACTIONS(863), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7451] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(546), 1,
-      anon_sym_LF,
-    STATE(260), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(865), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7468] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(540), 1,
-      anon_sym_LF,
-    STATE(264), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(469), 1,
-      sym_note,
-    ACTIONS(867), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7485] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(620), 1,
-      anon_sym_LF,
-    STATE(268), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(432), 1,
-      sym_note,
-    ACTIONS(869), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7502] = 5,
-    ACTIONS(658), 1,
-      anon_sym_LPAREN,
-    ACTIONS(871), 1,
-      sym_payee,
-    STATE(216), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(229), 1,
-      sym_code,
-    ACTIONS(662), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7519] = 2,
-    ACTIONS(873), 1,
-      anon_sym_LF,
-    ACTIONS(875), 5,
-      aux_sym_block_comment_token1,
-      anon_sym_end,
-      anon_sym_endcomment,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7530] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(616), 1,
-      anon_sym_LF,
-    STATE(270), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(453), 1,
-      sym_note,
-    ACTIONS(877), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7547] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(722), 1,
-      anon_sym_LF,
-    STATE(274), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(482), 1,
-      sym_note,
-    ACTIONS(879), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7564] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(726), 1,
-      anon_sym_LF,
-    STATE(276), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(438), 1,
-      sym_note,
-    ACTIONS(881), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7581] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(883), 1,
-      anon_sym_LF,
-    STATE(278), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(451), 1,
-      sym_note,
-    ACTIONS(885), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7598] = 5,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(887), 1,
-      anon_sym_LF,
-    STATE(280), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(471), 1,
-      sym_note,
-    ACTIONS(889), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7615] = 6,
-    ACTIONS(782), 1,
-      anon_sym_LF,
-    ACTIONS(891), 1,
-      aux_sym_note_token1,
-    ACTIONS(893), 1,
-      anon_sym_LBRACK,
-    ACTIONS(895), 1,
-      aux_sym_note_token2,
-    STATE(226), 1,
-      aux_sym_note_repeat1,
-    STATE(400), 1,
-      aux_sym_note_repeat2,
-  [7634] = 2,
-    ACTIONS(859), 1,
-      anon_sym_LF,
-    ACTIONS(738), 5,
-      aux_sym_block_comment_token1,
-      anon_sym_end,
-      anon_sym_endtest,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7645] = 4,
-    ACTIONS(897), 1,
-      aux_sym_note_token1,
-    ACTIONS(902), 1,
-      aux_sym_note_token2,
-    STATE(248), 1,
-      aux_sym_note_repeat1,
-    ACTIONS(900), 3,
-      anon_sym_LBRACK,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7660] = 2,
-    ACTIONS(873), 1,
-      anon_sym_LF,
-    ACTIONS(875), 5,
-      aux_sym_block_comment_token1,
-      anon_sym_end,
-      anon_sym_endtest,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7671] = 4,
-    ACTIONS(904), 1,
-      anon_sym_SPACE,
-    ACTIONS(907), 1,
-      anon_sym_TAB,
-    STATE(250), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(227), 3,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      sym_account_name,
-  [7686] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(24), 2,
-      sym_posting,
-      aux_sym_plain_xact_repeat1,
-  [7698] = 4,
-    ACTIONS(910), 1,
-      aux_sym_option_value_token1,
-    STATE(355), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(472), 1,
-      sym_filename,
-    ACTIONS(912), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7712] = 4,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(142), 1,
-      sym_negative_quantity,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7726] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(478), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7740] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(23), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-  [7752] = 1,
-    ACTIONS(914), 5,
+  [7414] = 1,
+    ACTIONS(917), 5,
       anon_sym_LF,
-      anon_sym_EQ,
-      anon_sym_SEMI,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7760] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(31), 2,
-      sym_posting,
-      aux_sym_plain_xact_repeat1,
-  [7772] = 2,
-    ACTIONS(916), 1,
-      anon_sym_LF,
-    ACTIONS(918), 4,
       anon_sym_,
       anon_sym_TAB2,
       anon_sym_TAB3,
       anon_sym_TAB_TAB,
-  [7782] = 2,
-    ACTIONS(920), 1,
+  [7422] = 4,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(137), 1,
+      sym_negative_quantity,
+    ACTIONS(569), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7436] = 2,
+    ACTIONS(919), 1,
       anon_sym_LF,
-    ACTIONS(922), 4,
+    ACTIONS(921), 4,
       anon_sym_,
       anon_sym_TAB2,
       anon_sym_TAB3,
       anon_sym_TAB_TAB,
-  [7792] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
+  [7446] = 3,
+    STATE(90), 1,
       aux_sym_whitespace_repeat1,
-    STATE(469), 1,
-      sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(569), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7806] = 4,
-    ACTIONS(902), 1,
-      aux_sym_note_token2,
-    ACTIONS(924), 1,
-      aux_sym_note_token1,
-    STATE(261), 1,
-      aux_sym_note_repeat1,
-    ACTIONS(900), 2,
-      anon_sym_LF,
-      anon_sym_LBRACK,
-  [7820] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(29), 2,
-      sym_posting,
-      aux_sym_plain_xact_repeat1,
-  [7832] = 3,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    ACTIONS(927), 2,
+    ACTIONS(923), 2,
       aux_sym__interval_date_spec_token3,
       aux_sym__interval_date_spec_token4,
-  [7844] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
+  [7458] = 4,
+    ACTIONS(925), 1,
+      anon_sym_LF,
+    ACTIONS(927), 1,
+      anon_sym_EQ,
+    STATE(260), 1,
       aux_sym_whitespace_repeat1,
-    STATE(432), 1,
-      sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(929), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7858] = 2,
-    ACTIONS(931), 1,
-      sym__dsep,
-    ACTIONS(929), 4,
+  [7472] = 2,
+    ACTIONS(500), 1,
       anon_sym_LF,
-      anon_sym_SEMI,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7868] = 2,
-    ACTIONS(515), 1,
-      anon_sym_LF,
-    ACTIONS(933), 4,
+    ACTIONS(931), 4,
       anon_sym_,
       anon_sym_TAB2,
       anon_sym_TAB3,
       anon_sym_TAB_TAB,
-  [7878] = 3,
-    STATE(121), 1,
+  [7482] = 3,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(20), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-  [7890] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
+  [7494] = 3,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    STATE(453), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7904] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(25), 2,
-      sym_posting,
-      aux_sym_plain_xact_repeat1,
-  [7916] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(482), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7930] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(26), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-  [7942] = 3,
-    STATE(116), 1,
+  [7506] = 4,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(134), 1,
+      sym_negative_quantity,
+    STATE(273), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(935), 2,
-      anon_sym_LF,
-      anon_sym_SEMI,
+    ACTIONS(933), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7520] = 4,
+    ACTIONS(935), 1,
+      aux_sym_option_value_token1,
+    STATE(346), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(476), 1,
+      sym_filename,
     ACTIONS(937), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [7954] = 1,
-    ACTIONS(939), 5,
-      anon_sym_LF,
-      anon_sym_,
-      anon_sym_TAB2,
-      anon_sym_TAB3,
-      anon_sym_TAB_TAB,
-  [7962] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(438), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [7976] = 2,
-    ACTIONS(491), 1,
+  [7534] = 2,
+    ACTIONS(939), 1,
       anon_sym_LF,
     ACTIONS(941), 4,
       anon_sym_,
       anon_sym_TAB2,
       anon_sym_TAB3,
       anon_sym_TAB_TAB,
-  [7986] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(451), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8000] = 2,
-    ACTIONS(943), 1,
-      anon_sym_LF,
-    ACTIONS(945), 4,
-      anon_sym_,
-      anon_sym_TAB2,
-      anon_sym_TAB3,
-      anon_sym_TAB_TAB,
-  [8010] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(471), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8024] = 4,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(143), 1,
-      sym_negative_quantity,
-    STATE(289), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(947), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8038] = 4,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(479), 1,
-      sym_note,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8052] = 1,
-    ACTIONS(949), 5,
-      anon_sym_LF,
-      anon_sym_,
-      anon_sym_TAB2,
-      anon_sym_TAB3,
-      anon_sym_TAB_TAB,
-  [8060] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(19), 2,
-      sym_posting,
-      aux_sym_plain_xact_repeat1,
-  [8072] = 1,
-    ACTIONS(951), 5,
-      anon_sym_LF,
-      anon_sym_SEMI,
-      anon_sym_RBRACK,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8080] = 2,
-    ACTIONS(955), 1,
-      anon_sym_SPACE,
-    ACTIONS(953), 4,
-      anon_sym_LPAREN,
-      anon_sym_LBRACK,
-      sym_account_name,
-      anon_sym_TAB,
-  [8090] = 4,
-    ACTIONS(957), 1,
-      aux_sym_option_value_token1,
-    STATE(355), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(440), 1,
-      sym_option_value,
-    ACTIONS(912), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8104] = 4,
-    ACTIONS(959), 1,
-      sym__quantity,
-    STATE(62), 1,
-      sym_negative_quantity,
-    STATE(290), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(961), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8118] = 1,
-    ACTIONS(963), 5,
+  [7544] = 1,
+    ACTIONS(943), 5,
       anon_sym_LF,
       anon_sym_EQ,
       anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8126] = 2,
-    ACTIONS(965), 1,
-      anon_sym_LF,
-    ACTIONS(967), 4,
-      anon_sym_,
-      anon_sym_TAB2,
-      anon_sym_TAB3,
-      anon_sym_TAB_TAB,
-  [8136] = 4,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    STATE(145), 1,
-      sym_negative_quantity,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8150] = 4,
-    ACTIONS(959), 1,
-      sym__quantity,
-    STATE(63), 1,
-      sym_negative_quantity,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8164] = 4,
-    ACTIONS(959), 1,
-      sym__quantity,
-    STATE(63), 1,
-      sym_negative_quantity,
-    STATE(292), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(969), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8178] = 4,
-    ACTIONS(959), 1,
-      sym__quantity,
-    STATE(64), 1,
-      sym_negative_quantity,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8192] = 4,
-    ACTIONS(497), 1,
+  [7552] = 4,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    STATE(98), 1,
+    STATE(176), 1,
       aux_sym_whitespace_repeat1,
-    STATE(490), 1,
+    STATE(465), 1,
       sym_note,
-    ACTIONS(558), 2,
+    ACTIONS(665), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8206] = 4,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(145), 1,
-      sym_negative_quantity,
-    STATE(253), 1,
+  [7566] = 3,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(971), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8220] = 3,
-    STATE(121), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-    STATE(27), 2,
+    STATE(24), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-  [8232] = 2,
-    ACTIONS(973), 1,
-      anon_sym_LF,
-    ACTIONS(975), 4,
-      anon_sym_,
-      anon_sym_TAB2,
-      anon_sym_TAB3,
-      anon_sym_TAB_TAB,
-  [8242] = 3,
-    STATE(121), 1,
+  [7578] = 3,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(236), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
     STATE(22), 2,
       sym_posting,
       aux_sym_plain_xact_repeat1,
-  [8254] = 3,
-    STATE(263), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(977), 2,
-      anon_sym_LF,
+  [7590] = 4,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(979), 2,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(459), 1,
+      sym_note,
+    ACTIONS(665), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8266] = 4,
-    ACTIONS(981), 1,
+  [7604] = 2,
+    ACTIONS(945), 1,
       anon_sym_LF,
-    ACTIONS(983), 1,
-      anon_sym_EQ,
-    STATE(285), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(985), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8280] = 3,
-    ACTIONS(987), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8291] = 3,
-    ACTIONS(989), 1,
-      sym_payee,
-    STATE(310), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(991), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8302] = 1,
-    ACTIONS(993), 4,
-      anon_sym_LF,
-      anon_sym_SEMI,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8309] = 3,
-    ACTIONS(995), 1,
-      anon_sym_RBRACE,
-    STATE(319), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(997), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8320] = 3,
-    ACTIONS(995), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(321), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(999), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8331] = 3,
-    ACTIONS(1001), 1,
-      anon_sym_EQ,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8342] = 3,
-    ACTIONS(1003), 1,
-      anon_sym_EQ,
-    STATE(305), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1005), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8353] = 3,
-    ACTIONS(1007), 1,
-      aux_sym_tag_directive_token1,
-    STATE(99), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(560), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8364] = 3,
-    ACTIONS(1009), 1,
-      aux_sym_word_directive_token1,
-    STATE(356), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1011), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8375] = 3,
-    ACTIONS(1013), 1,
+    ACTIONS(947), 4,
+      anon_sym_,
+      anon_sym_TAB2,
+      anon_sym_TAB3,
+      anon_sym_TAB_TAB,
+  [7614] = 4,
+    ACTIONS(949), 1,
       aux_sym_option_value_token1,
-    STATE(355), 1,
+    STATE(346), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(912), 2,
+    STATE(440), 1,
+      sym_option_value,
+    ACTIONS(937), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8386] = 3,
-    ACTIONS(1015), 1,
-      sym_payee,
-    STATE(216), 1,
+  [7628] = 4,
+    ACTIONS(875), 1,
+      aux_sym_note_token2,
+    ACTIONS(951), 1,
+      aux_sym_note_token1,
+    STATE(261), 1,
+      aux_sym_note_repeat1,
+    ACTIONS(873), 2,
+      anon_sym_LF,
+      anon_sym_LBRACK,
+  [7642] = 3,
+    STATE(125), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(662), 2,
+    ACTIONS(240), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8397] = 3,
-    ACTIONS(1015), 1,
-      sym_payee,
+    STATE(25), 2,
+      sym_posting,
+      aux_sym_plain_xact_repeat1,
+  [7654] = 3,
+    STATE(125), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(240), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(21), 2,
+      sym_posting,
+      aux_sym_plain_xact_repeat1,
+  [7666] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(437), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7680] = 3,
+    STATE(125), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(240), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(27), 2,
+      sym_posting,
+      aux_sym_plain_xact_repeat1,
+  [7692] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(460), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7706] = 1,
+    ACTIONS(954), 5,
+      anon_sym_LF,
+      anon_sym_,
+      anon_sym_TAB2,
+      anon_sym_TAB3,
+      anon_sym_TAB_TAB,
+  [7714] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(410), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7728] = 3,
+    STATE(105), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(956), 2,
+      anon_sym_LF,
+      anon_sym_SEMI,
+    ACTIONS(958), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7740] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(417), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7754] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(423), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7768] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(428), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7782] = 4,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(133), 1,
+      sym_negative_quantity,
+    ACTIONS(569), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7796] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(432), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7810] = 4,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(133), 1,
+      sym_negative_quantity,
+    STATE(244), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(960), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7824] = 3,
+    STATE(125), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(240), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(19), 2,
+      sym_posting,
+      aux_sym_plain_xact_repeat1,
+  [7836] = 4,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    STATE(435), 1,
+      sym_note,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7850] = 2,
+    ACTIONS(964), 1,
+      anon_sym_SPACE,
+    ACTIONS(962), 4,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+      sym_account_name,
+      anon_sym_TAB,
+  [7860] = 2,
+    ACTIONS(966), 1,
+      anon_sym_LF,
+    ACTIONS(968), 4,
+      anon_sym_,
+      anon_sym_TAB2,
+      anon_sym_TAB3,
+      anon_sym_TAB_TAB,
+  [7870] = 3,
+    STATE(125), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(240), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+    STATE(18), 2,
+      sym_posting,
+      aux_sym_plain_xact_repeat1,
+  [7882] = 3,
+    STATE(246), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(970), 2,
+      anon_sym_LF,
+      anon_sym_SEMI,
+    ACTIONS(972), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7894] = 2,
+    ACTIONS(976), 1,
+      sym__dsep,
+    ACTIONS(974), 4,
+      anon_sym_LF,
+      anon_sym_SEMI,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7904] = 2,
+    ACTIONS(504), 1,
+      anon_sym_LF,
+    ACTIONS(978), 4,
+      anon_sym_,
+      anon_sym_TAB2,
+      anon_sym_TAB3,
+      anon_sym_TAB_TAB,
+  [7914] = 1,
+    ACTIONS(980), 5,
+      anon_sym_LF,
+      anon_sym_EQ,
+      anon_sym_SEMI,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7922] = 1,
+    ACTIONS(964), 4,
+      anon_sym_LF,
+      anon_sym_SEMI,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7929] = 3,
+    ACTIONS(982), 1,
+      aux_sym_account_subdirective_token1,
+    STATE(349), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(984), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7940] = 3,
+    ACTIONS(986), 1,
+      aux_sym_option_value_token1,
+    STATE(346), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(937), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7951] = 3,
+    ACTIONS(988), 1,
+      aux_sym_word_directive_token2,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7962] = 3,
+    ACTIONS(990), 1,
+      anon_sym_EQ,
     STATE(325), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1017), 2,
+    ACTIONS(992), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8408] = 3,
-    ACTIONS(1019), 1,
+  [7973] = 3,
+    ACTIONS(994), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7984] = 3,
+    ACTIONS(994), 1,
+      sym_payee,
+    STATE(305), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(996), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [7995] = 3,
+    ACTIONS(998), 1,
       aux_sym_word_directive_token2,
-    STATE(98), 1,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8419] = 3,
-    ACTIONS(1021), 1,
-      sym_time,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8430] = 3,
-    ACTIONS(1023), 1,
-      sym_time,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8441] = 3,
-    ACTIONS(1025), 1,
-      sym_time,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8452] = 3,
-    ACTIONS(1025), 1,
-      sym_time,
-    STATE(313), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1027), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8463] = 1,
-    ACTIONS(1029), 4,
-      anon_sym_LF,
-      anon_sym_SEMI,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8470] = 3,
-    ACTIONS(1031), 1,
-      sym_time,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8481] = 3,
-    ACTIONS(1033), 1,
-      anon_sym_RBRACE,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8492] = 3,
-    ACTIONS(1033), 1,
-      anon_sym_RBRACE,
-    STATE(327), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1035), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8503] = 3,
-    ACTIONS(1033), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8514] = 3,
-    ACTIONS(1033), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(300), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1037), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8525] = 3,
-    ACTIONS(1039), 1,
+  [8006] = 3,
+    ACTIONS(1000), 1,
       aux_sym_account_subdirective_token1,
-    STATE(360), 1,
+    STATE(349), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1041), 2,
+    ACTIONS(984), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8536] = 3,
-    ACTIONS(1043), 1,
-      aux_sym_account_subdirective_token1,
-    STATE(360), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1041), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8547] = 3,
-    ACTIONS(1045), 1,
-      sym_payee,
-    STATE(216), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(662), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8558] = 3,
-    ACTIONS(1031), 1,
+  [8017] = 3,
+    ACTIONS(1002), 1,
       sym_time,
-    STATE(314), 1,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1047), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8569] = 3,
-    ACTIONS(987), 1,
-      anon_sym_RBRACE,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8580] = 3,
-    ACTIONS(1049), 1,
-      aux_sym_word_directive_token2,
-    STATE(98), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(558), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8591] = 3,
-    ACTIONS(1051), 1,
-      sym_payee,
-    STATE(216), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(662), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8602] = 3,
-    ACTIONS(1051), 1,
-      sym_payee,
-    STATE(336), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1053), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8613] = 1,
-    ACTIONS(1055), 4,
+  [8028] = 3,
+    ACTIONS(1004), 1,
       anon_sym_LF,
-      anon_sym_SEMI,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8620] = 3,
-    ACTIONS(871), 1,
-      sym_payee,
-    STATE(216), 1,
+    STATE(350), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(662), 2,
+    ACTIONS(1006), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8631] = 3,
-    ACTIONS(1057), 1,
-      sym_time,
-    STATE(315), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1059), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8642] = 3,
-    ACTIONS(1061), 1,
-      sym_time,
-    STATE(318), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1063), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8653] = 3,
-    ACTIONS(227), 1,
-      aux_sym_block_comment_token1,
-    STATE(335), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1065), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8664] = 3,
-    ACTIONS(989), 1,
-      sym_payee,
-    STATE(216), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(662), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8675] = 3,
-    ACTIONS(227), 1,
+  [8039] = 3,
+    ACTIONS(1008), 1,
       sym_query,
+    STATE(329), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1010), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8050] = 1,
+    ACTIONS(1012), 4,
+      anon_sym_LF,
+      anon_sym_SEMI,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8057] = 3,
+    ACTIONS(1014), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8068] = 3,
+    ACTIONS(1014), 1,
+      anon_sym_RBRACE,
+    STATE(311), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1016), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8079] = 3,
+    ACTIONS(1014), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8090] = 3,
+    ACTIONS(1014), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(312), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1018), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8101] = 3,
+    ACTIONS(1020), 1,
+      anon_sym_LF,
+    STATE(328), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1022), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8112] = 3,
+    ACTIONS(1024), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8123] = 3,
+    ACTIONS(1026), 1,
+      aux_sym_account_subdirective_token1,
+    STATE(349), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(984), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8134] = 3,
+    ACTIONS(1028), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8145] = 3,
+    ACTIONS(1030), 1,
+      aux_sym_account_subdirective_token1,
+    STATE(349), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(984), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8156] = 3,
+    ACTIONS(1032), 1,
+      aux_sym_account_subdirective_token1,
+    STATE(349), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(984), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8167] = 3,
+    ACTIONS(1002), 1,
+      sym_time,
+    STATE(344), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1034), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8178] = 3,
+    ACTIONS(877), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8189] = 3,
+    ACTIONS(1036), 1,
+      sym_time,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8200] = 3,
+    ACTIONS(1038), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8211] = 3,
+    ACTIONS(1038), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(91), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(571), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8222] = 3,
+    ACTIONS(1040), 1,
+      aux_sym_account_subdirective_token1,
+    STATE(349), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(984), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8233] = 3,
+    ACTIONS(1042), 1,
+      sym_time,
+    STATE(294), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1044), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8244] = 3,
+    ACTIONS(1036), 1,
+      sym_time,
+    STATE(345), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1046), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8255] = 3,
+    ACTIONS(1048), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8266] = 3,
+    ACTIONS(1050), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8277] = 3,
+    ACTIONS(1052), 1,
+      sym_time,
+    STATE(310), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1054), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8288] = 3,
+    ACTIONS(1056), 1,
+      aux_sym_tag_directive_token1,
+    STATE(90), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(569), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8299] = 3,
+    ACTIONS(1058), 1,
+      sym_payee,
+    STATE(176), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(665), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8310] = 3,
+    ACTIONS(1060), 1,
+      aux_sym_word_directive_token1,
+    STATE(347), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1062), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8321] = 4,
+    ACTIONS(37), 1,
+      aux_sym_word_directive_token2,
+    ACTIONS(61), 1,
+      sym__2d,
+    STATE(241), 1,
+      sym__single_date,
+    STATE(441), 1,
+      sym__4d,
+  [8334] = 3,
+    ACTIONS(1050), 1,
+      sym_payee,
+    STATE(320), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1064), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8345] = 3,
+    ACTIONS(1066), 1,
+      aux_sym_block_comment_token1,
     STATE(337), 1,
       aux_sym_whitespace_repeat1,
     ACTIONS(1068), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8686] = 3,
-    ACTIONS(1071), 1,
-      aux_sym_block_comment_token1,
-    STATE(335), 1,
+  [8356] = 3,
+    ACTIONS(1070), 1,
+      anon_sym_EQ,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1073), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8697] = 3,
-    ACTIONS(1075), 1,
-      aux_sym_note_token2,
-    STATE(344), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(829), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8708] = 1,
-    ACTIONS(1077), 4,
+  [8367] = 1,
+    ACTIONS(1072), 4,
       anon_sym_LF,
       anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8715] = 3,
-    ACTIONS(1079), 1,
-      sym_payee,
-    STATE(216), 1,
+  [8374] = 3,
+    ACTIONS(1074), 1,
+      anon_sym_RBRACE,
+    STATE(298), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(662), 2,
+    ACTIONS(1076), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8726] = 4,
-    ACTIONS(35), 1,
-      aux_sym_word_directive_token2,
-    ACTIONS(59), 1,
-      sym__2d,
-    STATE(283), 1,
-      sym__single_date,
-    STATE(443), 1,
-      sym__4d,
-  [8739] = 3,
-    ACTIONS(1075), 1,
-      aux_sym_note_token2,
-    STATE(344), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(1081), 2,
+  [8385] = 3,
+    ACTIONS(1078), 1,
+      aux_sym_block_comment_token1,
+    STATE(337), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1068), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8750] = 3,
+  [8396] = 3,
+    ACTIONS(510), 1,
+      sym_query,
+    STATE(329), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1080), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8407] = 3,
     ACTIONS(1083), 1,
       aux_sym_note_token2,
-    STATE(344), 1,
+    STATE(336), 1,
       aux_sym_note_repeat2,
-    ACTIONS(1086), 2,
+    ACTIONS(800), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8761] = 1,
-    ACTIONS(1088), 4,
+  [8418] = 3,
+    ACTIONS(1074), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(300), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1085), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8429] = 1,
+    ACTIONS(1087), 4,
       anon_sym_LF,
       anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8768] = 3,
-    ACTIONS(1090), 1,
-      aux_sym_account_subdirective_token1,
-    STATE(360), 1,
+  [8436] = 3,
+    ACTIONS(1089), 1,
+      sym_payee,
+    STATE(317), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1041), 2,
+    ACTIONS(1091), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8779] = 3,
-    ACTIONS(1092), 1,
-      aux_sym_account_subdirective_token1,
-    STATE(360), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1041), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8790] = 3,
-    ACTIONS(1094), 1,
-      aux_sym_note_token2,
-    STATE(350), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(1096), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8801] = 3,
-    ACTIONS(1098), 1,
-      aux_sym_account_subdirective_token1,
-    STATE(360), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1041), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8812] = 3,
-    ACTIONS(1075), 1,
-      aux_sym_note_token2,
-    STATE(344), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(1100), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8823] = 3,
-    ACTIONS(1102), 1,
-      aux_sym_note_token2,
-    STATE(352), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(1100), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8834] = 3,
-    ACTIONS(1075), 1,
-      aux_sym_note_token2,
-    STATE(344), 1,
-      aux_sym_note_repeat2,
-    ACTIONS(1104), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8845] = 3,
-    ACTIONS(1106), 1,
-      aux_sym_block_comment_token1,
-    STATE(335), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1073), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8856] = 3,
-    ACTIONS(1108), 1,
+  [8447] = 1,
+    ACTIONS(1093), 4,
       anon_sym_LF,
-    STATE(353), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1110), 2,
+      anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8867] = 3,
-    ACTIONS(227), 1,
-      aux_sym_option_value_token1,
-    STATE(355), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1112), 2,
+  [8454] = 3,
+    ACTIONS(1083), 1,
+      aux_sym_note_token2,
+    STATE(336), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(1095), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8878] = 3,
-    ACTIONS(227), 1,
-      aux_sym_word_directive_token1,
-    STATE(356), 1,
+  [8465] = 3,
+    ACTIONS(1097), 1,
+      aux_sym_note_token2,
+    STATE(336), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(1100), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8476] = 3,
+    ACTIONS(510), 1,
+      aux_sym_block_comment_token1,
+    STATE(337), 1,
       aux_sym_whitespace_repeat1,
+    ACTIONS(1102), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8487] = 3,
+    ACTIONS(1105), 1,
+      aux_sym_block_comment_token1,
+    STATE(337), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1068), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8498] = 3,
+    ACTIONS(1107), 1,
+      aux_sym_note_token2,
+    STATE(340), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(1109), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8509] = 3,
+    ACTIONS(1083), 1,
+      aux_sym_note_token2,
+    STATE(336), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(1111), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8520] = 3,
+    ACTIONS(1113), 1,
+      aux_sym_note_token2,
+    STATE(342), 1,
+      aux_sym_note_repeat2,
+    ACTIONS(1111), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8531] = 3,
+    ACTIONS(1083), 1,
+      aux_sym_note_token2,
+    STATE(336), 1,
+      aux_sym_note_repeat2,
     ACTIONS(1115), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8889] = 3,
-    ACTIONS(1118), 1,
-      aux_sym_block_comment_token1,
-    STATE(335), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1073), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8900] = 3,
-    ACTIONS(1120), 1,
-      sym_payee,
-    STATE(329), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1122), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8911] = 3,
-    ACTIONS(1124), 1,
-      sym_query,
-    STATE(337), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1126), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8922] = 3,
-    ACTIONS(185), 1,
-      aux_sym_account_subdirective_token1,
-    STATE(360), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1128), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8933] = 1,
-    ACTIONS(955), 4,
+  [8542] = 1,
+    ACTIONS(974), 4,
       anon_sym_LF,
       anon_sym_SEMI,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8940] = 1,
-    ACTIONS(929), 4,
-      anon_sym_LF,
-      anon_sym_SEMI,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8947] = 3,
-    ACTIONS(1131), 1,
-      aux_sym_block_comment_token1,
-    STATE(335), 1,
+  [8549] = 3,
+    ACTIONS(1117), 1,
+      sym_time,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1073), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8958] = 3,
-    ACTIONS(1133), 1,
-      anon_sym_LF,
-    STATE(338), 1,
+  [8560] = 3,
+    ACTIONS(1119), 1,
+      sym_time,
+    STATE(91), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1135), 2,
+    ACTIONS(571), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [8969] = 2,
-    STATE(201), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1137), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8977] = 2,
-    STATE(205), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1139), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [8985] = 3,
-    ACTIONS(1081), 1,
-      anon_sym_LF,
-    ACTIONS(1141), 1,
-      aux_sym_note_token2,
-    STATE(369), 1,
-      aux_sym_note_repeat2,
-  [8995] = 3,
-    ACTIONS(497), 1,
-      anon_sym_SEMI,
-    ACTIONS(1143), 1,
-      anon_sym_LF,
-    STATE(468), 1,
-      sym_note,
-  [9005] = 3,
-    ACTIONS(1086), 1,
-      anon_sym_LF,
-    ACTIONS(1145), 1,
-      aux_sym_note_token2,
-    STATE(369), 1,
-      aux_sym_note_repeat2,
-  [9015] = 2,
-    STATE(199), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1148), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9023] = 2,
-    STATE(119), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1150), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9031] = 2,
-    STATE(359), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1152), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9039] = 2,
-    STATE(112), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1154), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9047] = 2,
-    STATE(156), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1156), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9055] = 2,
-    STATE(328), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1158), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9063] = 3,
-    ACTIONS(1160), 1,
-      anon_sym_LF,
-    ACTIONS(1162), 1,
-      anon_sym_SEMI,
-    STATE(255), 1,
-      sym_note,
-  [9073] = 2,
-    STATE(307), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1164), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9081] = 2,
-    STATE(196), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1166), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9089] = 2,
-    STATE(132), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1168), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9097] = 2,
-    STATE(219), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1170), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9105] = 2,
-    STATE(349), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1172), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9113] = 2,
-    STATE(178), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1174), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9121] = 3,
-    ACTIONS(1100), 1,
-      anon_sym_LF,
-    ACTIONS(1141), 1,
-      aux_sym_note_token2,
-    STATE(369), 1,
-      aux_sym_note_repeat2,
-  [9131] = 2,
-    STATE(207), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1176), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9139] = 3,
-    ACTIONS(1100), 1,
-      anon_sym_LF,
-    ACTIONS(1178), 1,
-      aux_sym_note_token2,
-    STATE(398), 1,
-      aux_sym_note_repeat2,
-  [9149] = 2,
-    STATE(35), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1180), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9157] = 2,
-    STATE(323), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1182), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9165] = 3,
-    ACTIONS(1096), 1,
-      anon_sym_LF,
-    ACTIONS(1184), 1,
-      aux_sym_note_token2,
-    STATE(383), 1,
-      aux_sym_note_repeat2,
-  [9175] = 2,
-    STATE(324), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1186), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9183] = 2,
-    STATE(118), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1188), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9191] = 2,
-    STATE(252), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1190), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9199] = 2,
-    STATE(308), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1192), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9207] = 2,
-    STATE(131), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1194), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9215] = 3,
-    ACTIONS(1162), 1,
-      anon_sym_SEMI,
-    ACTIONS(1196), 1,
-      anon_sym_LF,
-    STATE(267), 1,
-      sym_note,
-  [9225] = 2,
-    STATE(309), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1198), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9233] = 2,
+  [8571] = 3,
+    ACTIONS(510), 1,
+      aux_sym_option_value_token1,
     STATE(346), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1200), 2,
+    ACTIONS(1121), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [9241] = 2,
+  [8582] = 3,
+    ACTIONS(510), 1,
+      aux_sym_word_directive_token1,
     STATE(347), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1202), 2,
+    ACTIONS(1124), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [9249] = 3,
-    ACTIONS(1104), 1,
+  [8593] = 1,
+    ACTIONS(1127), 4,
       anon_sym_LF,
-    ACTIONS(1141), 1,
-      aux_sym_note_token2,
-    STATE(369), 1,
-      aux_sym_note_repeat2,
-  [9259] = 3,
-    ACTIONS(497), 1,
       anon_sym_SEMI,
-    ACTIONS(839), 1,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8600] = 3,
+    ACTIONS(190), 1,
+      aux_sym_account_subdirective_token1,
+    STATE(349), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1129), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8611] = 3,
+    ACTIONS(1132), 1,
+      aux_sym_block_comment_token1,
+    STATE(337), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1068), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8622] = 3,
+    ACTIONS(1058), 1,
+      sym_payee,
+    STATE(290), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1134), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8633] = 3,
+    ACTIONS(800), 1,
       anon_sym_LF,
-    STATE(489), 1,
-      sym_note,
-  [9269] = 3,
-    ACTIONS(829), 1,
-      anon_sym_LF,
-    ACTIONS(1141), 1,
+    ACTIONS(1136), 1,
       aux_sym_note_token2,
-    STATE(369), 1,
+    STATE(359), 1,
       aux_sym_note_repeat2,
-  [9279] = 2,
-    STATE(208), 1,
+  [8643] = 2,
+    STATE(313), 1,
       aux_sym_whitespace_repeat1,
-    ACTIONS(1204), 2,
+    ACTIONS(1138), 2,
       anon_sym_SPACE,
       anon_sym_TAB,
-  [9287] = 2,
-    STATE(312), 1,
-      aux_sym_whitespace_repeat1,
-    ACTIONS(1206), 2,
-      anon_sym_SPACE,
-      anon_sym_TAB,
-  [9295] = 3,
-    ACTIONS(497), 1,
+  [8651] = 3,
+    ACTIONS(482), 1,
       anon_sym_SEMI,
-    ACTIONS(845), 1,
+    ACTIONS(905), 1,
       anon_sym_LF,
-    STATE(433), 1,
+    STATE(449), 1,
       sym_note,
-  [9305] = 2,
-    ACTIONS(855), 1,
-      anon_sym_EQ,
-    STATE(448), 1,
-      sym_effective_date,
-  [9312] = 2,
-    ACTIONS(855), 1,
-      anon_sym_EQ,
-    STATE(485), 1,
-      sym_effective_date,
-  [9319] = 2,
-    ACTIONS(1208), 1,
+  [8661] = 2,
+    STATE(188), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1140), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8669] = 2,
+    STATE(123), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1142), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8677] = 3,
+    ACTIONS(1144), 1,
+      anon_sym_LF,
+    ACTIONS(1146), 1,
+      anon_sym_SEMI,
+    STATE(249), 1,
+      sym_note,
+  [8687] = 3,
+    ACTIONS(1095), 1,
+      anon_sym_LF,
+    ACTIONS(1136), 1,
+      aux_sym_note_token2,
+    STATE(359), 1,
+      aux_sym_note_repeat2,
+  [8697] = 3,
+    ACTIONS(1100), 1,
+      anon_sym_LF,
+    ACTIONS(1148), 1,
+      aux_sym_note_token2,
+    STATE(359), 1,
+      aux_sym_note_repeat2,
+  [8707] = 2,
+    STATE(198), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1151), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8715] = 2,
+    STATE(191), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1153), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8723] = 2,
+    STATE(319), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1155), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8731] = 2,
+    STATE(292), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1157), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8739] = 2,
+    STATE(111), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1159), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8747] = 2,
+    STATE(106), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1161), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8755] = 2,
+    STATE(182), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1163), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8763] = 2,
+    STATE(104), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1165), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8771] = 2,
+    STATE(146), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1167), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8779] = 2,
+    STATE(113), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1169), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8787] = 2,
+    STATE(184), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1171), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8795] = 2,
+    STATE(165), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1173), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8803] = 2,
+    STATE(196), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1175), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8811] = 2,
+    STATE(65), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1177), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8819] = 2,
+    STATE(316), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1179), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8827] = 2,
+    STATE(286), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1181), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8835] = 2,
+    STATE(293), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1183), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8843] = 2,
+    STATE(304), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1185), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8851] = 2,
+    STATE(306), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1187), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8859] = 2,
+    STATE(307), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1189), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8867] = 3,
+    ACTIONS(1115), 1,
+      anon_sym_LF,
+    ACTIONS(1136), 1,
+      aux_sym_note_token2,
+    STATE(359), 1,
+      aux_sym_note_repeat2,
+  [8877] = 2,
+    STATE(252), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1191), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8885] = 3,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(1193), 1,
+      anon_sym_LF,
+    STATE(446), 1,
+      sym_note,
+  [8895] = 2,
+    STATE(321), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1195), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8903] = 2,
+    STATE(287), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1197), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8911] = 2,
+    STATE(296), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1199), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8919] = 2,
+    STATE(288), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1201), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8927] = 3,
+    ACTIONS(1111), 1,
+      anon_sym_LF,
+    ACTIONS(1136), 1,
+      aux_sym_note_token2,
+    STATE(359), 1,
+      aux_sym_note_repeat2,
+  [8937] = 2,
+    STATE(211), 1,
+      aux_sym_whitespace_repeat1,
+    ACTIONS(1203), 2,
+      anon_sym_SPACE,
+      anon_sym_TAB,
+  [8945] = 3,
+    ACTIONS(1111), 1,
+      anon_sym_LF,
+    ACTIONS(1205), 1,
+      aux_sym_note_token2,
+    STATE(380), 1,
+      aux_sym_note_repeat2,
+  [8955] = 3,
+    ACTIONS(1109), 1,
+      anon_sym_LF,
+    ACTIONS(1207), 1,
+      aux_sym_note_token2,
+    STATE(387), 1,
+      aux_sym_note_repeat2,
+  [8965] = 3,
+    ACTIONS(482), 1,
+      anon_sym_SEMI,
+    ACTIONS(856), 1,
+      anon_sym_LF,
+    STATE(474), 1,
+      sym_note,
+  [8975] = 3,
+    ACTIONS(1146), 1,
+      anon_sym_SEMI,
+    ACTIONS(1209), 1,
+      anon_sym_LF,
+    STATE(257), 1,
+      sym_note,
+  [8985] = 1,
+    ACTIONS(970), 2,
+      anon_sym_LF,
+      anon_sym_SEMI,
+  [8990] = 2,
+    ACTIONS(1211), 1,
       aux_sym_option_value_token1,
     STATE(440), 1,
       sym_option_value,
-  [9326] = 1,
-    ACTIONS(935), 2,
-      anon_sym_LF,
-      anon_sym_SEMI,
-  [9331] = 1,
-    ACTIONS(1210), 2,
-      anon_sym_LF,
-      anon_sym_SEMI,
-  [9336] = 2,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(143), 1,
-      sym_negative_quantity,
-  [9343] = 2,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(143), 1,
-      sym_quantity,
-  [9350] = 2,
-    ACTIONS(959), 1,
-      sym__quantity,
-    STATE(62), 1,
-      sym_negative_quantity,
-  [9357] = 2,
-    ACTIONS(788), 1,
-      sym__quantity,
-    STATE(62), 1,
-      sym_quantity,
-  [9364] = 2,
-    ACTIONS(855), 1,
+  [8997] = 2,
+    ACTIONS(893), 1,
       anon_sym_EQ,
-    STATE(428), 1,
+    STATE(418), 1,
       sym_effective_date,
-  [9371] = 1,
-    ACTIONS(977), 2,
+  [9004] = 1,
+    ACTIONS(1213), 2,
       anon_sym_LF,
       anon_sym_SEMI,
-  [9376] = 2,
-    ACTIONS(959), 1,
-      sym__quantity,
-    STATE(63), 1,
-      sym_negative_quantity,
-  [9383] = 2,
-    ACTIONS(788), 1,
-      sym__quantity,
-    STATE(63), 1,
-      sym_quantity,
-  [9390] = 2,
-    ACTIONS(629), 1,
-      sym__quantity,
-    STATE(145), 1,
-      sym_negative_quantity,
-  [9397] = 2,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(145), 1,
-      sym_quantity,
-  [9404] = 1,
-    ACTIONS(1212), 2,
-      anon_sym_LF,
-      anon_sym_SEMI,
-  [9409] = 1,
-    ACTIONS(1214), 2,
-      anon_sym_LF,
-      anon_sym_SEMI,
-  [9414] = 2,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(168), 1,
-      sym_quantity,
-  [9421] = 2,
-    ACTIONS(590), 1,
-      sym__quantity,
-    STATE(12), 1,
-      sym_quantity,
-  [9428] = 2,
-    ACTIONS(501), 1,
-      sym__quantity,
-    STATE(104), 1,
-      sym_quantity,
-  [9435] = 2,
-    ACTIONS(855), 1,
+  [9009] = 2,
+    ACTIONS(893), 1,
       anon_sym_EQ,
-    STATE(484), 1,
+    STATE(426), 1,
       sym_effective_date,
-  [9442] = 1,
-    ACTIONS(916), 1,
+  [9016] = 2,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(167), 1,
+      sym_quantity,
+  [9023] = 1,
+    ACTIONS(956), 2,
       anon_sym_LF,
-  [9446] = 1,
-    ACTIONS(1216), 1,
+      anon_sym_SEMI,
+  [9028] = 1,
+    ACTIONS(1215), 2,
       anon_sym_LF,
-  [9450] = 1,
-    ACTIONS(1218), 1,
+      anon_sym_SEMI,
+  [9033] = 2,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(133), 1,
+      sym_negative_quantity,
+  [9040] = 2,
+    ACTIONS(893), 1,
+      anon_sym_EQ,
+    STATE(471), 1,
+      sym_effective_date,
+  [9047] = 2,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(133), 1,
+      sym_quantity,
+  [9054] = 1,
+    ACTIONS(1217), 2,
       anon_sym_LF,
-  [9454] = 1,
-    ACTIONS(1220), 1,
-      anon_sym_RBRACK,
-  [9458] = 1,
-    ACTIONS(1222), 1,
+      anon_sym_SEMI,
+  [9059] = 2,
+    ACTIONS(639), 1,
+      sym__quantity,
+    STATE(134), 1,
+      sym_negative_quantity,
+  [9066] = 2,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(134), 1,
+      sym_quantity,
+  [9073] = 2,
+    ACTIONS(486), 1,
+      sym__quantity,
+    STATE(93), 1,
+      sym_quantity,
+  [9080] = 2,
+    ACTIONS(893), 1,
+      anon_sym_EQ,
+    STATE(470), 1,
+      sym_effective_date,
+  [9087] = 1,
+    ACTIONS(1219), 1,
       anon_sym_LF,
-  [9462] = 1,
-    ACTIONS(1224), 1,
+  [9091] = 1,
+    ACTIONS(734), 1,
       anon_sym_LF,
-  [9466] = 1,
-    ACTIONS(1226), 1,
-      anon_sym_LF,
-  [9470] = 1,
-    ACTIONS(616), 1,
-      anon_sym_LF,
-  [9474] = 1,
-    ACTIONS(1228), 1,
-      anon_sym_LF,
-  [9478] = 1,
-    ACTIONS(1230), 1,
-      anon_sym_LF,
-  [9482] = 1,
-    ACTIONS(1232), 1,
-      anon_sym_LF,
-  [9486] = 1,
-    ACTIONS(1234), 1,
-      anon_sym_LF,
-  [9490] = 1,
-    ACTIONS(1236), 1,
+  [9095] = 1,
+    ACTIONS(1221), 1,
+      sym_account_name,
+  [9099] = 1,
+    ACTIONS(1223), 1,
+      sym__dsep,
+  [9103] = 1,
+    ACTIONS(1225), 1,
       aux_sym_option_token1,
-  [9494] = 1,
-    ACTIONS(883), 1,
-      anon_sym_LF,
-  [9498] = 1,
-    ACTIONS(1238), 1,
-      anon_sym_LF,
-  [9502] = 1,
-    ACTIONS(1240), 1,
-      anon_sym_LF,
-  [9506] = 1,
-    ACTIONS(1242), 1,
-      anon_sym_RPAREN,
-  [9510] = 1,
-    ACTIONS(1244), 1,
-      sym__dsep,
-  [9514] = 1,
-    ACTIONS(931), 1,
-      sym__dsep,
-  [9518] = 1,
-    ACTIONS(1246), 1,
-      anon_sym_EQ,
-  [9522] = 1,
-    ACTIONS(1248), 1,
-      anon_sym_LF,
-  [9526] = 1,
-    ACTIONS(1250), 1,
+  [9107] = 1,
+    ACTIONS(1227), 1,
       ts_builtin_sym_end,
-  [9530] = 1,
-    ACTIONS(1252), 1,
+  [9111] = 1,
+    ACTIONS(1229), 1,
       anon_sym_LF,
-  [9534] = 1,
-    ACTIONS(1254), 1,
+  [9115] = 1,
+    ACTIONS(1231), 1,
+      anon_sym_LF,
+  [9119] = 1,
+    ACTIONS(738), 1,
+      anon_sym_LF,
+  [9123] = 1,
+    ACTIONS(1233), 1,
       anon_sym_RBRACK,
-  [9538] = 1,
-    ACTIONS(1256), 1,
+  [9127] = 1,
+    ACTIONS(911), 1,
       anon_sym_LF,
-  [9542] = 1,
-    ACTIONS(1258), 1,
+  [9131] = 1,
+    ACTIONS(1235), 1,
       anon_sym_LF,
-  [9546] = 1,
-    ACTIONS(887), 1,
+  [9135] = 1,
+    ACTIONS(1237), 1,
       anon_sym_LF,
-  [9550] = 1,
-    ACTIONS(1260), 1,
-      anon_sym_RPAREN,
-  [9554] = 1,
-    ACTIONS(722), 1,
-      anon_sym_LF,
-  [9558] = 1,
-    ACTIONS(1262), 1,
+  [9139] = 1,
+    ACTIONS(1239), 1,
       sym__2d,
-  [9562] = 1,
-    ACTIONS(1264), 1,
-      sym_account_name,
-  [9566] = 1,
-    ACTIONS(519), 1,
+  [9143] = 1,
+    ACTIONS(838), 1,
       anon_sym_LF,
-  [9570] = 1,
-    ACTIONS(1266), 1,
+  [9147] = 1,
+    ACTIONS(1241), 1,
       anon_sym_LF,
-  [9574] = 1,
-    ACTIONS(1268), 1,
+  [9151] = 1,
+    ACTIONS(1243), 1,
       anon_sym_LF,
-  [9578] = 1,
-    ACTIONS(1270), 1,
-      aux_sym_code_token1,
-  [9582] = 1,
-    ACTIONS(1272), 1,
-      anon_sym_LF,
-  [9586] = 1,
-    ACTIONS(1274), 1,
-      anon_sym_LF,
-  [9590] = 1,
-    ACTIONS(1276), 1,
-      sym__2d,
-  [9594] = 1,
-    ACTIONS(1278), 1,
-      anon_sym_LF,
-  [9598] = 1,
-    ACTIONS(1280), 1,
-      sym_account_name,
-  [9602] = 1,
-    ACTIONS(515), 1,
-      anon_sym_LF,
-  [9606] = 1,
-    ACTIONS(1282), 1,
-      anon_sym_LF,
-  [9610] = 1,
-    ACTIONS(1284), 1,
-      anon_sym_LF,
-  [9614] = 1,
-    ACTIONS(1286), 1,
-      anon_sym_LF,
-  [9618] = 1,
-    ACTIONS(620), 1,
-      anon_sym_LF,
-  [9622] = 1,
-    ACTIONS(1288), 1,
-      anon_sym_LF,
-  [9626] = 1,
-    ACTIONS(1290), 1,
-      anon_sym_LF,
-  [9630] = 1,
-    ACTIONS(1292), 1,
-      anon_sym_LF,
-  [9634] = 1,
-    ACTIONS(1260), 1,
+  [9155] = 1,
+    ACTIONS(1245), 1,
       anon_sym_RBRACK,
-  [9638] = 1,
-    ACTIONS(1294), 1,
+  [9159] = 1,
+    ACTIONS(1247), 1,
       aux_sym_option_value_token1,
-  [9642] = 1,
-    ACTIONS(690), 1,
+  [9163] = 1,
+    ACTIONS(846), 1,
+      anon_sym_LF,
+  [9167] = 1,
+    ACTIONS(919), 1,
+      anon_sym_LF,
+  [9171] = 1,
+    ACTIONS(1249), 1,
+      anon_sym_LF,
+  [9175] = 1,
+    ACTIONS(1251), 1,
+      anon_sym_LF,
+  [9179] = 1,
+    ACTIONS(1253), 1,
+      anon_sym_LF,
+  [9183] = 1,
+    ACTIONS(1255), 1,
+      anon_sym_LF,
+  [9187] = 1,
+    ACTIONS(1257), 1,
+      sym_account_name,
+  [9191] = 1,
+    ACTIONS(1259), 1,
+      anon_sym_LF,
+  [9195] = 1,
+    ACTIONS(1261), 1,
+      anon_sym_LF,
+  [9199] = 1,
+    ACTIONS(619), 1,
+      anon_sym_LF,
+  [9203] = 1,
+    ACTIONS(1263), 1,
+      anon_sym_LF,
+  [9207] = 1,
+    ACTIONS(1265), 1,
+      anon_sym_LF,
+  [9211] = 1,
+    ACTIONS(1267), 1,
+      anon_sym_LF,
+  [9215] = 1,
+    ACTIONS(976), 1,
       sym__dsep,
-  [9646] = 1,
-    ACTIONS(1296), 1,
-      anon_sym_LF,
-  [9650] = 1,
-    ACTIONS(1298), 1,
-      anon_sym_LF,
-  [9654] = 1,
-    ACTIONS(540), 1,
-      anon_sym_LF,
-  [9658] = 1,
-    ACTIONS(1300), 1,
-      anon_sym_LF,
-  [9662] = 1,
-    ACTIONS(1302), 1,
-      anon_sym_LF,
-  [9666] = 1,
-    ACTIONS(1304), 1,
-      anon_sym_LF,
-  [9670] = 1,
-    ACTIONS(726), 1,
-      anon_sym_LF,
-  [9674] = 1,
-    ACTIONS(1306), 1,
-      anon_sym_LF,
-  [9678] = 1,
-    ACTIONS(1308), 1,
-      anon_sym_RBRACK,
-  [9682] = 1,
-    ACTIONS(1310), 1,
-      anon_sym_RBRACK,
-  [9686] = 1,
-    ACTIONS(1312), 1,
-      anon_sym_LF,
-  [9690] = 1,
-    ACTIONS(943), 1,
-      anon_sym_LF,
-  [9694] = 1,
-    ACTIONS(1314), 1,
+  [9219] = 1,
+    ACTIONS(1269), 1,
       sym__2d,
-  [9698] = 1,
-    ACTIONS(1316), 1,
+  [9223] = 1,
+    ACTIONS(1271), 1,
       anon_sym_LF,
-  [9702] = 1,
-    ACTIONS(546), 1,
+  [9227] = 1,
+    ACTIONS(1273), 1,
+      anon_sym_RPAREN,
+  [9231] = 1,
+    ACTIONS(1275), 1,
+      sym__2d,
+  [9235] = 1,
+    ACTIONS(1277), 1,
       anon_sym_LF,
-  [9706] = 1,
-    ACTIONS(1318), 1,
+  [9239] = 1,
+    ACTIONS(500), 1,
       anon_sym_LF,
+  [9243] = 1,
+    ACTIONS(476), 1,
+      anon_sym_LF,
+  [9247] = 1,
+    ACTIONS(1279), 1,
+      anon_sym_LF,
+  [9251] = 1,
+    ACTIONS(1281), 1,
+      anon_sym_LF,
+  [9255] = 1,
+    ACTIONS(1283), 1,
+      anon_sym_LF,
+  [9259] = 1,
+    ACTIONS(1285), 1,
+      anon_sym_LF,
+  [9263] = 1,
+    ACTIONS(1287), 1,
+      anon_sym_EQ,
+  [9267] = 1,
+    ACTIONS(1289), 1,
+      anon_sym_LF,
+  [9271] = 1,
+    ACTIONS(1291), 1,
+      anon_sym_LF,
+  [9275] = 1,
+    ACTIONS(1293), 1,
+      anon_sym_LF,
+  [9279] = 1,
+    ACTIONS(1295), 1,
+      anon_sym_LF,
+  [9283] = 1,
+    ACTIONS(685), 1,
+      sym__dsep,
+  [9287] = 1,
+    ACTIONS(553), 1,
+      anon_sym_LF,
+  [9291] = 1,
+    ACTIONS(629), 1,
+      anon_sym_LF,
+  [9295] = 1,
+    ACTIONS(1297), 1,
+      anon_sym_LF,
+  [9299] = 1,
+    ACTIONS(1299), 1,
+      anon_sym_LF,
+  [9303] = 1,
+    ACTIONS(1301), 1,
+      anon_sym_RPAREN,
+  [9307] = 1,
+    ACTIONS(1303), 1,
+      aux_sym_code_token1,
+  [9311] = 1,
+    ACTIONS(557), 1,
+      anon_sym_LF,
+  [9315] = 1,
+    ACTIONS(1305), 1,
+      anon_sym_LF,
+  [9319] = 1,
+    ACTIONS(1307), 1,
+      anon_sym_LF,
+  [9323] = 1,
+    ACTIONS(1309), 1,
+      anon_sym_LF,
+  [9327] = 1,
+    ACTIONS(1311), 1,
+      anon_sym_LF,
+  [9331] = 1,
+    ACTIONS(1313), 1,
+      anon_sym_RBRACK,
+  [9335] = 1,
+    ACTIONS(1315), 1,
+      anon_sym_RBRACK,
+  [9339] = 1,
+    ACTIONS(1317), 1,
+      anon_sym_LF,
+  [9343] = 1,
+    ACTIONS(1319), 1,
+      anon_sym_LF,
+  [9347] = 1,
+    ACTIONS(1321), 1,
+      anon_sym_LF,
+  [9351] = 1,
+    ACTIONS(1323), 1,
+      anon_sym_LF,
+  [9355] = 1,
+    ACTIONS(1325), 1,
+      anon_sym_LF,
+  [9359] = 1,
+    ACTIONS(1273), 1,
+      anon_sym_RBRACK,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 130,
-  [SMALL_STATE(4)] = 260,
-  [SMALL_STATE(5)] = 313,
-  [SMALL_STATE(6)] = 366,
-  [SMALL_STATE(7)] = 419,
-  [SMALL_STATE(8)] = 471,
-  [SMALL_STATE(9)] = 523,
-  [SMALL_STATE(10)] = 575,
-  [SMALL_STATE(11)] = 620,
-  [SMALL_STATE(12)] = 672,
-  [SMALL_STATE(13)] = 724,
-  [SMALL_STATE(14)] = 774,
-  [SMALL_STATE(15)] = 824,
-  [SMALL_STATE(16)] = 871,
-  [SMALL_STATE(17)] = 918,
-  [SMALL_STATE(18)] = 965,
-  [SMALL_STATE(19)] = 1010,
-  [SMALL_STATE(20)] = 1056,
-  [SMALL_STATE(21)] = 1102,
-  [SMALL_STATE(22)] = 1148,
-  [SMALL_STATE(23)] = 1194,
-  [SMALL_STATE(24)] = 1240,
-  [SMALL_STATE(25)] = 1286,
-  [SMALL_STATE(26)] = 1332,
-  [SMALL_STATE(27)] = 1378,
-  [SMALL_STATE(28)] = 1424,
-  [SMALL_STATE(29)] = 1464,
-  [SMALL_STATE(30)] = 1510,
-  [SMALL_STATE(31)] = 1550,
-  [SMALL_STATE(32)] = 1596,
-  [SMALL_STATE(33)] = 1633,
-  [SMALL_STATE(34)] = 1670,
-  [SMALL_STATE(35)] = 1707,
-  [SMALL_STATE(36)] = 1760,
-  [SMALL_STATE(37)] = 1797,
-  [SMALL_STATE(38)] = 1834,
-  [SMALL_STATE(39)] = 1871,
-  [SMALL_STATE(40)] = 1908,
-  [SMALL_STATE(41)] = 1945,
-  [SMALL_STATE(42)] = 1982,
-  [SMALL_STATE(43)] = 2019,
-  [SMALL_STATE(44)] = 2056,
-  [SMALL_STATE(45)] = 2093,
-  [SMALL_STATE(46)] = 2130,
+  [SMALL_STATE(3)] = 134,
+  [SMALL_STATE(4)] = 268,
+  [SMALL_STATE(5)] = 322,
+  [SMALL_STATE(6)] = 376,
+  [SMALL_STATE(7)] = 430,
+  [SMALL_STATE(8)] = 483,
+  [SMALL_STATE(9)] = 536,
+  [SMALL_STATE(10)] = 589,
+  [SMALL_STATE(11)] = 634,
+  [SMALL_STATE(12)] = 684,
+  [SMALL_STATE(13)] = 732,
+  [SMALL_STATE(14)] = 780,
+  [SMALL_STATE(15)] = 830,
+  [SMALL_STATE(16)] = 880,
+  [SMALL_STATE(17)] = 928,
+  [SMALL_STATE(18)] = 975,
+  [SMALL_STATE(19)] = 1022,
+  [SMALL_STATE(20)] = 1069,
+  [SMALL_STATE(21)] = 1116,
+  [SMALL_STATE(22)] = 1163,
+  [SMALL_STATE(23)] = 1210,
+  [SMALL_STATE(24)] = 1257,
+  [SMALL_STATE(25)] = 1304,
+  [SMALL_STATE(26)] = 1351,
+  [SMALL_STATE(27)] = 1398,
+  [SMALL_STATE(28)] = 1445,
+  [SMALL_STATE(29)] = 1483,
+  [SMALL_STATE(30)] = 1521,
+  [SMALL_STATE(31)] = 1559,
+  [SMALL_STATE(32)] = 1597,
+  [SMALL_STATE(33)] = 1635,
+  [SMALL_STATE(34)] = 1673,
+  [SMALL_STATE(35)] = 1711,
+  [SMALL_STATE(36)] = 1749,
+  [SMALL_STATE(37)] = 1787,
+  [SMALL_STATE(38)] = 1825,
+  [SMALL_STATE(39)] = 1863,
+  [SMALL_STATE(40)] = 1901,
+  [SMALL_STATE(41)] = 1939,
+  [SMALL_STATE(42)] = 1977,
+  [SMALL_STATE(43)] = 2015,
+  [SMALL_STATE(44)] = 2053,
+  [SMALL_STATE(45)] = 2091,
+  [SMALL_STATE(46)] = 2129,
   [SMALL_STATE(47)] = 2167,
-  [SMALL_STATE(48)] = 2204,
-  [SMALL_STATE(49)] = 2241,
-  [SMALL_STATE(50)] = 2278,
-  [SMALL_STATE(51)] = 2315,
-  [SMALL_STATE(52)] = 2352,
-  [SMALL_STATE(53)] = 2389,
-  [SMALL_STATE(54)] = 2426,
-  [SMALL_STATE(55)] = 2463,
-  [SMALL_STATE(56)] = 2500,
-  [SMALL_STATE(57)] = 2537,
-  [SMALL_STATE(58)] = 2574,
-  [SMALL_STATE(59)] = 2611,
-  [SMALL_STATE(60)] = 2648,
-  [SMALL_STATE(61)] = 2685,
-  [SMALL_STATE(62)] = 2722,
-  [SMALL_STATE(63)] = 2759,
-  [SMALL_STATE(64)] = 2796,
-  [SMALL_STATE(65)] = 2833,
-  [SMALL_STATE(66)] = 2870,
-  [SMALL_STATE(67)] = 2907,
-  [SMALL_STATE(68)] = 2944,
-  [SMALL_STATE(69)] = 2982,
-  [SMALL_STATE(70)] = 3020,
-  [SMALL_STATE(71)] = 3058,
-  [SMALL_STATE(72)] = 3096,
-  [SMALL_STATE(73)] = 3134,
-  [SMALL_STATE(74)] = 3172,
-  [SMALL_STATE(75)] = 3210,
-  [SMALL_STATE(76)] = 3248,
-  [SMALL_STATE(77)] = 3283,
-  [SMALL_STATE(78)] = 3318,
-  [SMALL_STATE(79)] = 3353,
-  [SMALL_STATE(80)] = 3388,
-  [SMALL_STATE(81)] = 3423,
-  [SMALL_STATE(82)] = 3458,
-  [SMALL_STATE(83)] = 3493,
-  [SMALL_STATE(84)] = 3528,
-  [SMALL_STATE(85)] = 3563,
-  [SMALL_STATE(86)] = 3598,
-  [SMALL_STATE(87)] = 3633,
-  [SMALL_STATE(88)] = 3668,
-  [SMALL_STATE(89)] = 3703,
-  [SMALL_STATE(90)] = 3738,
-  [SMALL_STATE(91)] = 3773,
-  [SMALL_STATE(92)] = 3808,
-  [SMALL_STATE(93)] = 3872,
-  [SMALL_STATE(94)] = 3936,
-  [SMALL_STATE(95)] = 4000,
-  [SMALL_STATE(96)] = 4061,
-  [SMALL_STATE(97)] = 4122,
-  [SMALL_STATE(98)] = 4183,
-  [SMALL_STATE(99)] = 4210,
-  [SMALL_STATE(100)] = 4237,
-  [SMALL_STATE(101)] = 4259,
-  [SMALL_STATE(102)] = 4286,
-  [SMALL_STATE(103)] = 4313,
-  [SMALL_STATE(104)] = 4342,
-  [SMALL_STATE(105)] = 4371,
-  [SMALL_STATE(106)] = 4395,
-  [SMALL_STATE(107)] = 4414,
-  [SMALL_STATE(108)] = 4433,
-  [SMALL_STATE(109)] = 4474,
-  [SMALL_STATE(110)] = 4515,
-  [SMALL_STATE(111)] = 4556,
-  [SMALL_STATE(112)] = 4597,
-  [SMALL_STATE(113)] = 4629,
-  [SMALL_STATE(114)] = 4667,
-  [SMALL_STATE(115)] = 4705,
-  [SMALL_STATE(116)] = 4743,
-  [SMALL_STATE(117)] = 4771,
-  [SMALL_STATE(118)] = 4809,
-  [SMALL_STATE(119)] = 4841,
-  [SMALL_STATE(120)] = 4873,
-  [SMALL_STATE(121)] = 4904,
-  [SMALL_STATE(122)] = 4939,
-  [SMALL_STATE(123)] = 4970,
-  [SMALL_STATE(124)] = 5001,
-  [SMALL_STATE(125)] = 5032,
-  [SMALL_STATE(126)] = 5063,
-  [SMALL_STATE(127)] = 5094,
-  [SMALL_STATE(128)] = 5125,
-  [SMALL_STATE(129)] = 5156,
-  [SMALL_STATE(130)] = 5187,
-  [SMALL_STATE(131)] = 5218,
-  [SMALL_STATE(132)] = 5249,
-  [SMALL_STATE(133)] = 5280,
-  [SMALL_STATE(134)] = 5311,
-  [SMALL_STATE(135)] = 5342,
-  [SMALL_STATE(136)] = 5372,
-  [SMALL_STATE(137)] = 5404,
-  [SMALL_STATE(138)] = 5436,
-  [SMALL_STATE(139)] = 5468,
-  [SMALL_STATE(140)] = 5500,
-  [SMALL_STATE(141)] = 5532,
-  [SMALL_STATE(142)] = 5548,
-  [SMALL_STATE(143)] = 5564,
-  [SMALL_STATE(144)] = 5580,
-  [SMALL_STATE(145)] = 5612,
-  [SMALL_STATE(146)] = 5628,
-  [SMALL_STATE(147)] = 5657,
-  [SMALL_STATE(148)] = 5686,
-  [SMALL_STATE(149)] = 5715,
-  [SMALL_STATE(150)] = 5744,
-  [SMALL_STATE(151)] = 5773,
-  [SMALL_STATE(152)] = 5802,
-  [SMALL_STATE(153)] = 5820,
-  [SMALL_STATE(154)] = 5842,
-  [SMALL_STATE(155)] = 5868,
-  [SMALL_STATE(156)] = 5888,
-  [SMALL_STATE(157)] = 5904,
-  [SMALL_STATE(158)] = 5920,
-  [SMALL_STATE(159)] = 5942,
-  [SMALL_STATE(160)] = 5964,
-  [SMALL_STATE(161)] = 5988,
-  [SMALL_STATE(162)] = 6011,
-  [SMALL_STATE(163)] = 6034,
-  [SMALL_STATE(164)] = 6057,
-  [SMALL_STATE(165)] = 6080,
-  [SMALL_STATE(166)] = 6093,
-  [SMALL_STATE(167)] = 6116,
-  [SMALL_STATE(168)] = 6139,
-  [SMALL_STATE(169)] = 6158,
-  [SMALL_STATE(170)] = 6181,
-  [SMALL_STATE(171)] = 6204,
-  [SMALL_STATE(172)] = 6227,
-  [SMALL_STATE(173)] = 6250,
-  [SMALL_STATE(174)] = 6273,
-  [SMALL_STATE(175)] = 6292,
-  [SMALL_STATE(176)] = 6315,
-  [SMALL_STATE(177)] = 6338,
-  [SMALL_STATE(178)] = 6361,
-  [SMALL_STATE(179)] = 6384,
-  [SMALL_STATE(180)] = 6407,
-  [SMALL_STATE(181)] = 6426,
-  [SMALL_STATE(182)] = 6449,
-  [SMALL_STATE(183)] = 6472,
-  [SMALL_STATE(184)] = 6495,
-  [SMALL_STATE(185)] = 6514,
-  [SMALL_STATE(186)] = 6535,
-  [SMALL_STATE(187)] = 6558,
-  [SMALL_STATE(188)] = 6581,
-  [SMALL_STATE(189)] = 6602,
-  [SMALL_STATE(190)] = 6622,
-  [SMALL_STATE(191)] = 6644,
-  [SMALL_STATE(192)] = 6664,
-  [SMALL_STATE(193)] = 6680,
-  [SMALL_STATE(194)] = 6692,
-  [SMALL_STATE(195)] = 6712,
-  [SMALL_STATE(196)] = 6724,
-  [SMALL_STATE(197)] = 6740,
-  [SMALL_STATE(198)] = 6760,
-  [SMALL_STATE(199)] = 6780,
-  [SMALL_STATE(200)] = 6802,
-  [SMALL_STATE(201)] = 6822,
-  [SMALL_STATE(202)] = 6844,
-  [SMALL_STATE(203)] = 6864,
-  [SMALL_STATE(204)] = 6884,
-  [SMALL_STATE(205)] = 6904,
-  [SMALL_STATE(206)] = 6920,
-  [SMALL_STATE(207)] = 6942,
-  [SMALL_STATE(208)] = 6964,
-  [SMALL_STATE(209)] = 6980,
-  [SMALL_STATE(210)] = 7000,
-  [SMALL_STATE(211)] = 7022,
-  [SMALL_STATE(212)] = 7034,
-  [SMALL_STATE(213)] = 7054,
-  [SMALL_STATE(214)] = 7076,
-  [SMALL_STATE(215)] = 7086,
-  [SMALL_STATE(216)] = 7108,
-  [SMALL_STATE(217)] = 7122,
-  [SMALL_STATE(218)] = 7144,
-  [SMALL_STATE(219)] = 7166,
-  [SMALL_STATE(220)] = 7182,
-  [SMALL_STATE(221)] = 7202,
-  [SMALL_STATE(222)] = 7224,
-  [SMALL_STATE(223)] = 7244,
-  [SMALL_STATE(224)] = 7260,
-  [SMALL_STATE(225)] = 7280,
-  [SMALL_STATE(226)] = 7297,
-  [SMALL_STATE(227)] = 7316,
-  [SMALL_STATE(228)] = 7333,
-  [SMALL_STATE(229)] = 7350,
-  [SMALL_STATE(230)] = 7367,
-  [SMALL_STATE(231)] = 7384,
-  [SMALL_STATE(232)] = 7397,
-  [SMALL_STATE(233)] = 7406,
-  [SMALL_STATE(234)] = 7417,
-  [SMALL_STATE(235)] = 7434,
-  [SMALL_STATE(236)] = 7451,
-  [SMALL_STATE(237)] = 7468,
-  [SMALL_STATE(238)] = 7485,
-  [SMALL_STATE(239)] = 7502,
-  [SMALL_STATE(240)] = 7519,
-  [SMALL_STATE(241)] = 7530,
-  [SMALL_STATE(242)] = 7547,
-  [SMALL_STATE(243)] = 7564,
-  [SMALL_STATE(244)] = 7581,
-  [SMALL_STATE(245)] = 7598,
-  [SMALL_STATE(246)] = 7615,
-  [SMALL_STATE(247)] = 7634,
-  [SMALL_STATE(248)] = 7645,
-  [SMALL_STATE(249)] = 7660,
-  [SMALL_STATE(250)] = 7671,
-  [SMALL_STATE(251)] = 7686,
-  [SMALL_STATE(252)] = 7698,
-  [SMALL_STATE(253)] = 7712,
-  [SMALL_STATE(254)] = 7726,
-  [SMALL_STATE(255)] = 7740,
-  [SMALL_STATE(256)] = 7752,
-  [SMALL_STATE(257)] = 7760,
-  [SMALL_STATE(258)] = 7772,
-  [SMALL_STATE(259)] = 7782,
-  [SMALL_STATE(260)] = 7792,
-  [SMALL_STATE(261)] = 7806,
-  [SMALL_STATE(262)] = 7820,
-  [SMALL_STATE(263)] = 7832,
-  [SMALL_STATE(264)] = 7844,
-  [SMALL_STATE(265)] = 7858,
-  [SMALL_STATE(266)] = 7868,
-  [SMALL_STATE(267)] = 7878,
-  [SMALL_STATE(268)] = 7890,
-  [SMALL_STATE(269)] = 7904,
-  [SMALL_STATE(270)] = 7916,
-  [SMALL_STATE(271)] = 7930,
-  [SMALL_STATE(272)] = 7942,
-  [SMALL_STATE(273)] = 7954,
-  [SMALL_STATE(274)] = 7962,
-  [SMALL_STATE(275)] = 7976,
-  [SMALL_STATE(276)] = 7986,
-  [SMALL_STATE(277)] = 8000,
-  [SMALL_STATE(278)] = 8010,
-  [SMALL_STATE(279)] = 8024,
-  [SMALL_STATE(280)] = 8038,
-  [SMALL_STATE(281)] = 8052,
-  [SMALL_STATE(282)] = 8060,
-  [SMALL_STATE(283)] = 8072,
-  [SMALL_STATE(284)] = 8080,
-  [SMALL_STATE(285)] = 8090,
-  [SMALL_STATE(286)] = 8104,
-  [SMALL_STATE(287)] = 8118,
-  [SMALL_STATE(288)] = 8126,
-  [SMALL_STATE(289)] = 8136,
-  [SMALL_STATE(290)] = 8150,
-  [SMALL_STATE(291)] = 8164,
-  [SMALL_STATE(292)] = 8178,
-  [SMALL_STATE(293)] = 8192,
-  [SMALL_STATE(294)] = 8206,
-  [SMALL_STATE(295)] = 8220,
-  [SMALL_STATE(296)] = 8232,
-  [SMALL_STATE(297)] = 8242,
-  [SMALL_STATE(298)] = 8254,
-  [SMALL_STATE(299)] = 8266,
-  [SMALL_STATE(300)] = 8280,
-  [SMALL_STATE(301)] = 8291,
-  [SMALL_STATE(302)] = 8302,
-  [SMALL_STATE(303)] = 8309,
-  [SMALL_STATE(304)] = 8320,
-  [SMALL_STATE(305)] = 8331,
-  [SMALL_STATE(306)] = 8342,
-  [SMALL_STATE(307)] = 8353,
-  [SMALL_STATE(308)] = 8364,
-  [SMALL_STATE(309)] = 8375,
-  [SMALL_STATE(310)] = 8386,
-  [SMALL_STATE(311)] = 8397,
-  [SMALL_STATE(312)] = 8408,
-  [SMALL_STATE(313)] = 8419,
-  [SMALL_STATE(314)] = 8430,
-  [SMALL_STATE(315)] = 8441,
-  [SMALL_STATE(316)] = 8452,
-  [SMALL_STATE(317)] = 8463,
-  [SMALL_STATE(318)] = 8470,
-  [SMALL_STATE(319)] = 8481,
-  [SMALL_STATE(320)] = 8492,
-  [SMALL_STATE(321)] = 8503,
-  [SMALL_STATE(322)] = 8514,
-  [SMALL_STATE(323)] = 8525,
-  [SMALL_STATE(324)] = 8536,
-  [SMALL_STATE(325)] = 8547,
-  [SMALL_STATE(326)] = 8558,
-  [SMALL_STATE(327)] = 8569,
-  [SMALL_STATE(328)] = 8580,
-  [SMALL_STATE(329)] = 8591,
-  [SMALL_STATE(330)] = 8602,
-  [SMALL_STATE(331)] = 8613,
-  [SMALL_STATE(332)] = 8620,
-  [SMALL_STATE(333)] = 8631,
-  [SMALL_STATE(334)] = 8642,
-  [SMALL_STATE(335)] = 8653,
-  [SMALL_STATE(336)] = 8664,
-  [SMALL_STATE(337)] = 8675,
-  [SMALL_STATE(338)] = 8686,
-  [SMALL_STATE(339)] = 8697,
-  [SMALL_STATE(340)] = 8708,
-  [SMALL_STATE(341)] = 8715,
-  [SMALL_STATE(342)] = 8726,
-  [SMALL_STATE(343)] = 8739,
-  [SMALL_STATE(344)] = 8750,
-  [SMALL_STATE(345)] = 8761,
-  [SMALL_STATE(346)] = 8768,
-  [SMALL_STATE(347)] = 8779,
-  [SMALL_STATE(348)] = 8790,
-  [SMALL_STATE(349)] = 8801,
-  [SMALL_STATE(350)] = 8812,
-  [SMALL_STATE(351)] = 8823,
-  [SMALL_STATE(352)] = 8834,
-  [SMALL_STATE(353)] = 8845,
-  [SMALL_STATE(354)] = 8856,
-  [SMALL_STATE(355)] = 8867,
-  [SMALL_STATE(356)] = 8878,
-  [SMALL_STATE(357)] = 8889,
-  [SMALL_STATE(358)] = 8900,
-  [SMALL_STATE(359)] = 8911,
-  [SMALL_STATE(360)] = 8922,
-  [SMALL_STATE(361)] = 8933,
-  [SMALL_STATE(362)] = 8940,
-  [SMALL_STATE(363)] = 8947,
-  [SMALL_STATE(364)] = 8958,
-  [SMALL_STATE(365)] = 8969,
-  [SMALL_STATE(366)] = 8977,
-  [SMALL_STATE(367)] = 8985,
-  [SMALL_STATE(368)] = 8995,
-  [SMALL_STATE(369)] = 9005,
-  [SMALL_STATE(370)] = 9015,
-  [SMALL_STATE(371)] = 9023,
-  [SMALL_STATE(372)] = 9031,
-  [SMALL_STATE(373)] = 9039,
-  [SMALL_STATE(374)] = 9047,
-  [SMALL_STATE(375)] = 9055,
-  [SMALL_STATE(376)] = 9063,
-  [SMALL_STATE(377)] = 9073,
-  [SMALL_STATE(378)] = 9081,
-  [SMALL_STATE(379)] = 9089,
-  [SMALL_STATE(380)] = 9097,
-  [SMALL_STATE(381)] = 9105,
-  [SMALL_STATE(382)] = 9113,
-  [SMALL_STATE(383)] = 9121,
-  [SMALL_STATE(384)] = 9131,
-  [SMALL_STATE(385)] = 9139,
-  [SMALL_STATE(386)] = 9149,
-  [SMALL_STATE(387)] = 9157,
-  [SMALL_STATE(388)] = 9165,
-  [SMALL_STATE(389)] = 9175,
-  [SMALL_STATE(390)] = 9183,
-  [SMALL_STATE(391)] = 9191,
-  [SMALL_STATE(392)] = 9199,
-  [SMALL_STATE(393)] = 9207,
-  [SMALL_STATE(394)] = 9215,
-  [SMALL_STATE(395)] = 9225,
-  [SMALL_STATE(396)] = 9233,
-  [SMALL_STATE(397)] = 9241,
-  [SMALL_STATE(398)] = 9249,
-  [SMALL_STATE(399)] = 9259,
-  [SMALL_STATE(400)] = 9269,
-  [SMALL_STATE(401)] = 9279,
-  [SMALL_STATE(402)] = 9287,
-  [SMALL_STATE(403)] = 9295,
-  [SMALL_STATE(404)] = 9305,
-  [SMALL_STATE(405)] = 9312,
-  [SMALL_STATE(406)] = 9319,
-  [SMALL_STATE(407)] = 9326,
-  [SMALL_STATE(408)] = 9331,
-  [SMALL_STATE(409)] = 9336,
-  [SMALL_STATE(410)] = 9343,
-  [SMALL_STATE(411)] = 9350,
-  [SMALL_STATE(412)] = 9357,
-  [SMALL_STATE(413)] = 9364,
-  [SMALL_STATE(414)] = 9371,
-  [SMALL_STATE(415)] = 9376,
-  [SMALL_STATE(416)] = 9383,
-  [SMALL_STATE(417)] = 9390,
-  [SMALL_STATE(418)] = 9397,
-  [SMALL_STATE(419)] = 9404,
-  [SMALL_STATE(420)] = 9409,
-  [SMALL_STATE(421)] = 9414,
-  [SMALL_STATE(422)] = 9421,
-  [SMALL_STATE(423)] = 9428,
-  [SMALL_STATE(424)] = 9435,
-  [SMALL_STATE(425)] = 9442,
-  [SMALL_STATE(426)] = 9446,
-  [SMALL_STATE(427)] = 9450,
-  [SMALL_STATE(428)] = 9454,
-  [SMALL_STATE(429)] = 9458,
-  [SMALL_STATE(430)] = 9462,
-  [SMALL_STATE(431)] = 9466,
-  [SMALL_STATE(432)] = 9470,
-  [SMALL_STATE(433)] = 9474,
-  [SMALL_STATE(434)] = 9478,
-  [SMALL_STATE(435)] = 9482,
-  [SMALL_STATE(436)] = 9486,
-  [SMALL_STATE(437)] = 9490,
-  [SMALL_STATE(438)] = 9494,
-  [SMALL_STATE(439)] = 9498,
-  [SMALL_STATE(440)] = 9502,
-  [SMALL_STATE(441)] = 9506,
-  [SMALL_STATE(442)] = 9510,
-  [SMALL_STATE(443)] = 9514,
-  [SMALL_STATE(444)] = 9518,
-  [SMALL_STATE(445)] = 9522,
-  [SMALL_STATE(446)] = 9526,
-  [SMALL_STATE(447)] = 9530,
-  [SMALL_STATE(448)] = 9534,
-  [SMALL_STATE(449)] = 9538,
-  [SMALL_STATE(450)] = 9542,
-  [SMALL_STATE(451)] = 9546,
-  [SMALL_STATE(452)] = 9550,
-  [SMALL_STATE(453)] = 9554,
-  [SMALL_STATE(454)] = 9558,
-  [SMALL_STATE(455)] = 9562,
-  [SMALL_STATE(456)] = 9566,
-  [SMALL_STATE(457)] = 9570,
-  [SMALL_STATE(458)] = 9574,
-  [SMALL_STATE(459)] = 9578,
-  [SMALL_STATE(460)] = 9582,
-  [SMALL_STATE(461)] = 9586,
-  [SMALL_STATE(462)] = 9590,
-  [SMALL_STATE(463)] = 9594,
-  [SMALL_STATE(464)] = 9598,
-  [SMALL_STATE(465)] = 9602,
-  [SMALL_STATE(466)] = 9606,
-  [SMALL_STATE(467)] = 9610,
-  [SMALL_STATE(468)] = 9614,
-  [SMALL_STATE(469)] = 9618,
-  [SMALL_STATE(470)] = 9622,
-  [SMALL_STATE(471)] = 9626,
-  [SMALL_STATE(472)] = 9630,
-  [SMALL_STATE(473)] = 9634,
-  [SMALL_STATE(474)] = 9638,
-  [SMALL_STATE(475)] = 9642,
-  [SMALL_STATE(476)] = 9646,
-  [SMALL_STATE(477)] = 9650,
-  [SMALL_STATE(478)] = 9654,
-  [SMALL_STATE(479)] = 9658,
-  [SMALL_STATE(480)] = 9662,
-  [SMALL_STATE(481)] = 9666,
-  [SMALL_STATE(482)] = 9670,
-  [SMALL_STATE(483)] = 9674,
-  [SMALL_STATE(484)] = 9678,
-  [SMALL_STATE(485)] = 9682,
-  [SMALL_STATE(486)] = 9686,
-  [SMALL_STATE(487)] = 9690,
-  [SMALL_STATE(488)] = 9694,
-  [SMALL_STATE(489)] = 9698,
-  [SMALL_STATE(490)] = 9702,
-  [SMALL_STATE(491)] = 9706,
+  [SMALL_STATE(48)] = 2205,
+  [SMALL_STATE(49)] = 2243,
+  [SMALL_STATE(50)] = 2281,
+  [SMALL_STATE(51)] = 2319,
+  [SMALL_STATE(52)] = 2357,
+  [SMALL_STATE(53)] = 2395,
+  [SMALL_STATE(54)] = 2433,
+  [SMALL_STATE(55)] = 2471,
+  [SMALL_STATE(56)] = 2509,
+  [SMALL_STATE(57)] = 2547,
+  [SMALL_STATE(58)] = 2585,
+  [SMALL_STATE(59)] = 2623,
+  [SMALL_STATE(60)] = 2662,
+  [SMALL_STATE(61)] = 2701,
+  [SMALL_STATE(62)] = 2740,
+  [SMALL_STATE(63)] = 2779,
+  [SMALL_STATE(64)] = 2818,
+  [SMALL_STATE(65)] = 2857,
+  [SMALL_STATE(66)] = 2910,
+  [SMALL_STATE(67)] = 2949,
+  [SMALL_STATE(68)] = 2988,
+  [SMALL_STATE(69)] = 3024,
+  [SMALL_STATE(70)] = 3060,
+  [SMALL_STATE(71)] = 3096,
+  [SMALL_STATE(72)] = 3132,
+  [SMALL_STATE(73)] = 3168,
+  [SMALL_STATE(74)] = 3204,
+  [SMALL_STATE(75)] = 3240,
+  [SMALL_STATE(76)] = 3276,
+  [SMALL_STATE(77)] = 3312,
+  [SMALL_STATE(78)] = 3348,
+  [SMALL_STATE(79)] = 3384,
+  [SMALL_STATE(80)] = 3420,
+  [SMALL_STATE(81)] = 3456,
+  [SMALL_STATE(82)] = 3492,
+  [SMALL_STATE(83)] = 3528,
+  [SMALL_STATE(84)] = 3564,
+  [SMALL_STATE(85)] = 3628,
+  [SMALL_STATE(86)] = 3692,
+  [SMALL_STATE(87)] = 3756,
+  [SMALL_STATE(88)] = 3817,
+  [SMALL_STATE(89)] = 3878,
+  [SMALL_STATE(90)] = 3939,
+  [SMALL_STATE(91)] = 3968,
+  [SMALL_STATE(92)] = 3995,
+  [SMALL_STATE(93)] = 4017,
+  [SMALL_STATE(94)] = 4046,
+  [SMALL_STATE(95)] = 4073,
+  [SMALL_STATE(96)] = 4100,
+  [SMALL_STATE(97)] = 4129,
+  [SMALL_STATE(98)] = 4153,
+  [SMALL_STATE(99)] = 4194,
+  [SMALL_STATE(100)] = 4213,
+  [SMALL_STATE(101)] = 4254,
+  [SMALL_STATE(102)] = 4273,
+  [SMALL_STATE(103)] = 4314,
+  [SMALL_STATE(104)] = 4355,
+  [SMALL_STATE(105)] = 4387,
+  [SMALL_STATE(106)] = 4415,
+  [SMALL_STATE(107)] = 4447,
+  [SMALL_STATE(108)] = 4485,
+  [SMALL_STATE(109)] = 4523,
+  [SMALL_STATE(110)] = 4561,
+  [SMALL_STATE(111)] = 4599,
+  [SMALL_STATE(112)] = 4631,
+  [SMALL_STATE(113)] = 4662,
+  [SMALL_STATE(114)] = 4693,
+  [SMALL_STATE(115)] = 4724,
+  [SMALL_STATE(116)] = 4755,
+  [SMALL_STATE(117)] = 4786,
+  [SMALL_STATE(118)] = 4817,
+  [SMALL_STATE(119)] = 4848,
+  [SMALL_STATE(120)] = 4879,
+  [SMALL_STATE(121)] = 4910,
+  [SMALL_STATE(122)] = 4941,
+  [SMALL_STATE(123)] = 4972,
+  [SMALL_STATE(124)] = 5003,
+  [SMALL_STATE(125)] = 5034,
+  [SMALL_STATE(126)] = 5069,
+  [SMALL_STATE(127)] = 5100,
+  [SMALL_STATE(128)] = 5132,
+  [SMALL_STATE(129)] = 5148,
+  [SMALL_STATE(130)] = 5178,
+  [SMALL_STATE(131)] = 5210,
+  [SMALL_STATE(132)] = 5242,
+  [SMALL_STATE(133)] = 5274,
+  [SMALL_STATE(134)] = 5290,
+  [SMALL_STATE(135)] = 5306,
+  [SMALL_STATE(136)] = 5338,
+  [SMALL_STATE(137)] = 5370,
+  [SMALL_STATE(138)] = 5386,
+  [SMALL_STATE(139)] = 5415,
+  [SMALL_STATE(140)] = 5444,
+  [SMALL_STATE(141)] = 5473,
+  [SMALL_STATE(142)] = 5502,
+  [SMALL_STATE(143)] = 5531,
+  [SMALL_STATE(144)] = 5560,
+  [SMALL_STATE(145)] = 5582,
+  [SMALL_STATE(146)] = 5600,
+  [SMALL_STATE(147)] = 5616,
+  [SMALL_STATE(148)] = 5638,
+  [SMALL_STATE(149)] = 5664,
+  [SMALL_STATE(150)] = 5680,
+  [SMALL_STATE(151)] = 5704,
+  [SMALL_STATE(152)] = 5724,
+  [SMALL_STATE(153)] = 5747,
+  [SMALL_STATE(154)] = 5760,
+  [SMALL_STATE(155)] = 5783,
+  [SMALL_STATE(156)] = 5806,
+  [SMALL_STATE(157)] = 5829,
+  [SMALL_STATE(158)] = 5850,
+  [SMALL_STATE(159)] = 5873,
+  [SMALL_STATE(160)] = 5896,
+  [SMALL_STATE(161)] = 5915,
+  [SMALL_STATE(162)] = 5938,
+  [SMALL_STATE(163)] = 5961,
+  [SMALL_STATE(164)] = 5984,
+  [SMALL_STATE(165)] = 6003,
+  [SMALL_STATE(166)] = 6026,
+  [SMALL_STATE(167)] = 6049,
+  [SMALL_STATE(168)] = 6068,
+  [SMALL_STATE(169)] = 6091,
+  [SMALL_STATE(170)] = 6114,
+  [SMALL_STATE(171)] = 6137,
+  [SMALL_STATE(172)] = 6160,
+  [SMALL_STATE(173)] = 6183,
+  [SMALL_STATE(174)] = 6206,
+  [SMALL_STATE(175)] = 6227,
+  [SMALL_STATE(176)] = 6250,
+  [SMALL_STATE(177)] = 6265,
+  [SMALL_STATE(178)] = 6284,
+  [SMALL_STATE(179)] = 6307,
+  [SMALL_STATE(180)] = 6330,
+  [SMALL_STATE(181)] = 6353,
+  [SMALL_STATE(182)] = 6375,
+  [SMALL_STATE(183)] = 6391,
+  [SMALL_STATE(184)] = 6413,
+  [SMALL_STATE(185)] = 6429,
+  [SMALL_STATE(186)] = 6439,
+  [SMALL_STATE(187)] = 6459,
+  [SMALL_STATE(188)] = 6481,
+  [SMALL_STATE(189)] = 6503,
+  [SMALL_STATE(190)] = 6515,
+  [SMALL_STATE(191)] = 6535,
+  [SMALL_STATE(192)] = 6551,
+  [SMALL_STATE(193)] = 6563,
+  [SMALL_STATE(194)] = 6583,
+  [SMALL_STATE(195)] = 6603,
+  [SMALL_STATE(196)] = 6619,
+  [SMALL_STATE(197)] = 6641,
+  [SMALL_STATE(198)] = 6661,
+  [SMALL_STATE(199)] = 6683,
+  [SMALL_STATE(200)] = 6703,
+  [SMALL_STATE(201)] = 6723,
+  [SMALL_STATE(202)] = 6743,
+  [SMALL_STATE(203)] = 6763,
+  [SMALL_STATE(204)] = 6783,
+  [SMALL_STATE(205)] = 6805,
+  [SMALL_STATE(206)] = 6825,
+  [SMALL_STATE(207)] = 6845,
+  [SMALL_STATE(208)] = 6867,
+  [SMALL_STATE(209)] = 6889,
+  [SMALL_STATE(210)] = 6901,
+  [SMALL_STATE(211)] = 6923,
+  [SMALL_STATE(212)] = 6939,
+  [SMALL_STATE(213)] = 6961,
+  [SMALL_STATE(214)] = 6978,
+  [SMALL_STATE(215)] = 6995,
+  [SMALL_STATE(216)] = 7006,
+  [SMALL_STATE(217)] = 7023,
+  [SMALL_STATE(218)] = 7034,
+  [SMALL_STATE(219)] = 7051,
+  [SMALL_STATE(220)] = 7068,
+  [SMALL_STATE(221)] = 7087,
+  [SMALL_STATE(222)] = 7104,
+  [SMALL_STATE(223)] = 7121,
+  [SMALL_STATE(224)] = 7132,
+  [SMALL_STATE(225)] = 7151,
+  [SMALL_STATE(226)] = 7168,
+  [SMALL_STATE(227)] = 7183,
+  [SMALL_STATE(228)] = 7194,
+  [SMALL_STATE(229)] = 7211,
+  [SMALL_STATE(230)] = 7226,
+  [SMALL_STATE(231)] = 7243,
+  [SMALL_STATE(232)] = 7260,
+  [SMALL_STATE(233)] = 7277,
+  [SMALL_STATE(234)] = 7290,
+  [SMALL_STATE(235)] = 7307,
+  [SMALL_STATE(236)] = 7324,
+  [SMALL_STATE(237)] = 7341,
+  [SMALL_STATE(238)] = 7358,
+  [SMALL_STATE(239)] = 7375,
+  [SMALL_STATE(240)] = 7384,
+  [SMALL_STATE(241)] = 7394,
+  [SMALL_STATE(242)] = 7402,
+  [SMALL_STATE(243)] = 7414,
+  [SMALL_STATE(244)] = 7422,
+  [SMALL_STATE(245)] = 7436,
+  [SMALL_STATE(246)] = 7446,
+  [SMALL_STATE(247)] = 7458,
+  [SMALL_STATE(248)] = 7472,
+  [SMALL_STATE(249)] = 7482,
+  [SMALL_STATE(250)] = 7494,
+  [SMALL_STATE(251)] = 7506,
+  [SMALL_STATE(252)] = 7520,
+  [SMALL_STATE(253)] = 7534,
+  [SMALL_STATE(254)] = 7544,
+  [SMALL_STATE(255)] = 7552,
+  [SMALL_STATE(256)] = 7566,
+  [SMALL_STATE(257)] = 7578,
+  [SMALL_STATE(258)] = 7590,
+  [SMALL_STATE(259)] = 7604,
+  [SMALL_STATE(260)] = 7614,
+  [SMALL_STATE(261)] = 7628,
+  [SMALL_STATE(262)] = 7642,
+  [SMALL_STATE(263)] = 7654,
+  [SMALL_STATE(264)] = 7666,
+  [SMALL_STATE(265)] = 7680,
+  [SMALL_STATE(266)] = 7692,
+  [SMALL_STATE(267)] = 7706,
+  [SMALL_STATE(268)] = 7714,
+  [SMALL_STATE(269)] = 7728,
+  [SMALL_STATE(270)] = 7740,
+  [SMALL_STATE(271)] = 7754,
+  [SMALL_STATE(272)] = 7768,
+  [SMALL_STATE(273)] = 7782,
+  [SMALL_STATE(274)] = 7796,
+  [SMALL_STATE(275)] = 7810,
+  [SMALL_STATE(276)] = 7824,
+  [SMALL_STATE(277)] = 7836,
+  [SMALL_STATE(278)] = 7850,
+  [SMALL_STATE(279)] = 7860,
+  [SMALL_STATE(280)] = 7870,
+  [SMALL_STATE(281)] = 7882,
+  [SMALL_STATE(282)] = 7894,
+  [SMALL_STATE(283)] = 7904,
+  [SMALL_STATE(284)] = 7914,
+  [SMALL_STATE(285)] = 7922,
+  [SMALL_STATE(286)] = 7929,
+  [SMALL_STATE(287)] = 7940,
+  [SMALL_STATE(288)] = 7951,
+  [SMALL_STATE(289)] = 7962,
+  [SMALL_STATE(290)] = 7973,
+  [SMALL_STATE(291)] = 7984,
+  [SMALL_STATE(292)] = 7995,
+  [SMALL_STATE(293)] = 8006,
+  [SMALL_STATE(294)] = 8017,
+  [SMALL_STATE(295)] = 8028,
+  [SMALL_STATE(296)] = 8039,
+  [SMALL_STATE(297)] = 8050,
+  [SMALL_STATE(298)] = 8057,
+  [SMALL_STATE(299)] = 8068,
+  [SMALL_STATE(300)] = 8079,
+  [SMALL_STATE(301)] = 8090,
+  [SMALL_STATE(302)] = 8101,
+  [SMALL_STATE(303)] = 8112,
+  [SMALL_STATE(304)] = 8123,
+  [SMALL_STATE(305)] = 8134,
+  [SMALL_STATE(306)] = 8145,
+  [SMALL_STATE(307)] = 8156,
+  [SMALL_STATE(308)] = 8167,
+  [SMALL_STATE(309)] = 8178,
+  [SMALL_STATE(310)] = 8189,
+  [SMALL_STATE(311)] = 8200,
+  [SMALL_STATE(312)] = 8211,
+  [SMALL_STATE(313)] = 8222,
+  [SMALL_STATE(314)] = 8233,
+  [SMALL_STATE(315)] = 8244,
+  [SMALL_STATE(316)] = 8255,
+  [SMALL_STATE(317)] = 8266,
+  [SMALL_STATE(318)] = 8277,
+  [SMALL_STATE(319)] = 8288,
+  [SMALL_STATE(320)] = 8299,
+  [SMALL_STATE(321)] = 8310,
+  [SMALL_STATE(322)] = 8321,
+  [SMALL_STATE(323)] = 8334,
+  [SMALL_STATE(324)] = 8345,
+  [SMALL_STATE(325)] = 8356,
+  [SMALL_STATE(326)] = 8367,
+  [SMALL_STATE(327)] = 8374,
+  [SMALL_STATE(328)] = 8385,
+  [SMALL_STATE(329)] = 8396,
+  [SMALL_STATE(330)] = 8407,
+  [SMALL_STATE(331)] = 8418,
+  [SMALL_STATE(332)] = 8429,
+  [SMALL_STATE(333)] = 8436,
+  [SMALL_STATE(334)] = 8447,
+  [SMALL_STATE(335)] = 8454,
+  [SMALL_STATE(336)] = 8465,
+  [SMALL_STATE(337)] = 8476,
+  [SMALL_STATE(338)] = 8487,
+  [SMALL_STATE(339)] = 8498,
+  [SMALL_STATE(340)] = 8509,
+  [SMALL_STATE(341)] = 8520,
+  [SMALL_STATE(342)] = 8531,
+  [SMALL_STATE(343)] = 8542,
+  [SMALL_STATE(344)] = 8549,
+  [SMALL_STATE(345)] = 8560,
+  [SMALL_STATE(346)] = 8571,
+  [SMALL_STATE(347)] = 8582,
+  [SMALL_STATE(348)] = 8593,
+  [SMALL_STATE(349)] = 8600,
+  [SMALL_STATE(350)] = 8611,
+  [SMALL_STATE(351)] = 8622,
+  [SMALL_STATE(352)] = 8633,
+  [SMALL_STATE(353)] = 8643,
+  [SMALL_STATE(354)] = 8651,
+  [SMALL_STATE(355)] = 8661,
+  [SMALL_STATE(356)] = 8669,
+  [SMALL_STATE(357)] = 8677,
+  [SMALL_STATE(358)] = 8687,
+  [SMALL_STATE(359)] = 8697,
+  [SMALL_STATE(360)] = 8707,
+  [SMALL_STATE(361)] = 8715,
+  [SMALL_STATE(362)] = 8723,
+  [SMALL_STATE(363)] = 8731,
+  [SMALL_STATE(364)] = 8739,
+  [SMALL_STATE(365)] = 8747,
+  [SMALL_STATE(366)] = 8755,
+  [SMALL_STATE(367)] = 8763,
+  [SMALL_STATE(368)] = 8771,
+  [SMALL_STATE(369)] = 8779,
+  [SMALL_STATE(370)] = 8787,
+  [SMALL_STATE(371)] = 8795,
+  [SMALL_STATE(372)] = 8803,
+  [SMALL_STATE(373)] = 8811,
+  [SMALL_STATE(374)] = 8819,
+  [SMALL_STATE(375)] = 8827,
+  [SMALL_STATE(376)] = 8835,
+  [SMALL_STATE(377)] = 8843,
+  [SMALL_STATE(378)] = 8851,
+  [SMALL_STATE(379)] = 8859,
+  [SMALL_STATE(380)] = 8867,
+  [SMALL_STATE(381)] = 8877,
+  [SMALL_STATE(382)] = 8885,
+  [SMALL_STATE(383)] = 8895,
+  [SMALL_STATE(384)] = 8903,
+  [SMALL_STATE(385)] = 8911,
+  [SMALL_STATE(386)] = 8919,
+  [SMALL_STATE(387)] = 8927,
+  [SMALL_STATE(388)] = 8937,
+  [SMALL_STATE(389)] = 8945,
+  [SMALL_STATE(390)] = 8955,
+  [SMALL_STATE(391)] = 8965,
+  [SMALL_STATE(392)] = 8975,
+  [SMALL_STATE(393)] = 8985,
+  [SMALL_STATE(394)] = 8990,
+  [SMALL_STATE(395)] = 8997,
+  [SMALL_STATE(396)] = 9004,
+  [SMALL_STATE(397)] = 9009,
+  [SMALL_STATE(398)] = 9016,
+  [SMALL_STATE(399)] = 9023,
+  [SMALL_STATE(400)] = 9028,
+  [SMALL_STATE(401)] = 9033,
+  [SMALL_STATE(402)] = 9040,
+  [SMALL_STATE(403)] = 9047,
+  [SMALL_STATE(404)] = 9054,
+  [SMALL_STATE(405)] = 9059,
+  [SMALL_STATE(406)] = 9066,
+  [SMALL_STATE(407)] = 9073,
+  [SMALL_STATE(408)] = 9080,
+  [SMALL_STATE(409)] = 9087,
+  [SMALL_STATE(410)] = 9091,
+  [SMALL_STATE(411)] = 9095,
+  [SMALL_STATE(412)] = 9099,
+  [SMALL_STATE(413)] = 9103,
+  [SMALL_STATE(414)] = 9107,
+  [SMALL_STATE(415)] = 9111,
+  [SMALL_STATE(416)] = 9115,
+  [SMALL_STATE(417)] = 9119,
+  [SMALL_STATE(418)] = 9123,
+  [SMALL_STATE(419)] = 9127,
+  [SMALL_STATE(420)] = 9131,
+  [SMALL_STATE(421)] = 9135,
+  [SMALL_STATE(422)] = 9139,
+  [SMALL_STATE(423)] = 9143,
+  [SMALL_STATE(424)] = 9147,
+  [SMALL_STATE(425)] = 9151,
+  [SMALL_STATE(426)] = 9155,
+  [SMALL_STATE(427)] = 9159,
+  [SMALL_STATE(428)] = 9163,
+  [SMALL_STATE(429)] = 9167,
+  [SMALL_STATE(430)] = 9171,
+  [SMALL_STATE(431)] = 9175,
+  [SMALL_STATE(432)] = 9179,
+  [SMALL_STATE(433)] = 9183,
+  [SMALL_STATE(434)] = 9187,
+  [SMALL_STATE(435)] = 9191,
+  [SMALL_STATE(436)] = 9195,
+  [SMALL_STATE(437)] = 9199,
+  [SMALL_STATE(438)] = 9203,
+  [SMALL_STATE(439)] = 9207,
+  [SMALL_STATE(440)] = 9211,
+  [SMALL_STATE(441)] = 9215,
+  [SMALL_STATE(442)] = 9219,
+  [SMALL_STATE(443)] = 9223,
+  [SMALL_STATE(444)] = 9227,
+  [SMALL_STATE(445)] = 9231,
+  [SMALL_STATE(446)] = 9235,
+  [SMALL_STATE(447)] = 9239,
+  [SMALL_STATE(448)] = 9243,
+  [SMALL_STATE(449)] = 9247,
+  [SMALL_STATE(450)] = 9251,
+  [SMALL_STATE(451)] = 9255,
+  [SMALL_STATE(452)] = 9259,
+  [SMALL_STATE(453)] = 9263,
+  [SMALL_STATE(454)] = 9267,
+  [SMALL_STATE(455)] = 9271,
+  [SMALL_STATE(456)] = 9275,
+  [SMALL_STATE(457)] = 9279,
+  [SMALL_STATE(458)] = 9283,
+  [SMALL_STATE(459)] = 9287,
+  [SMALL_STATE(460)] = 9291,
+  [SMALL_STATE(461)] = 9295,
+  [SMALL_STATE(462)] = 9299,
+  [SMALL_STATE(463)] = 9303,
+  [SMALL_STATE(464)] = 9307,
+  [SMALL_STATE(465)] = 9311,
+  [SMALL_STATE(466)] = 9315,
+  [SMALL_STATE(467)] = 9319,
+  [SMALL_STATE(468)] = 9323,
+  [SMALL_STATE(469)] = 9327,
+  [SMALL_STATE(470)] = 9331,
+  [SMALL_STATE(471)] = 9335,
+  [SMALL_STATE(472)] = 9339,
+  [SMALL_STATE(473)] = 9343,
+  [SMALL_STATE(474)] = 9347,
+  [SMALL_STATE(475)] = 9351,
+  [SMALL_STATE(476)] = 9355,
+  [SMALL_STATE(477)] = 9359,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -14945,633 +14428,636 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
   [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(458),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(437),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(437),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(377),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(395),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(402),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(443),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(378),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(382),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(172),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
-  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(442),
-  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
-  [67] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
-  [70] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(86),
-  [73] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(364),
-  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(458),
-  [79] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(354),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(437),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(437),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(372),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(384),
-  [94] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(366),
-  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(377),
-  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(391),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(392),
-  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(395),
-  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(402),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(443),
-  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(370),
-  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(365),
-  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(375),
-  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(378),
-  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(379),
-  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(380),
-  [133] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(382),
-  [136] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(172),
-  [139] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(172),
-  [142] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(175),
-  [145] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(386),
-  [148] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(442),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_directive, 4, 0, 0),
-  [153] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_directive, 4, 0, 0),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_directive, 5, 0, 0),
-  [159] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_directive, 5, 0, 0),
-  [161] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_account_directive_repeat1, 2, 0, 0),
-  [163] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_account_directive_repeat1, 2, 0, 0),
-  [165] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_account_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(135),
-  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_directive, 5, 0, 0),
-  [170] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_directive, 5, 0, 0),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [174] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_directive, 4, 0, 0),
-  [176] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_directive, 4, 0, 0),
-  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_commodity_directive_repeat1, 2, 0, 0),
-  [180] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_commodity_directive_repeat1, 2, 0, 0),
-  [182] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_commodity_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(154),
-  [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0),
-  [187] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
-  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 1, 0, 0),
-  [192] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 1, 0, 0),
-  [194] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 2, 0, 0),
-  [202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 2, 0, 0),
-  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 3, 0, 0),
-  [208] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 3, 0, 0),
-  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_tag_directive_repeat1, 2, 0, 0),
-  [212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_tag_directive_repeat1, 2, 0, 0),
-  [214] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_tag_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(234),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag_directive, 3, 0, 0),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag_directive, 3, 0, 0),
-  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag_directive, 4, 0, 0),
-  [225] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag_directive, 4, 0, 0),
-  [227] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0),
-  [229] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
-  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 3, 0, 0),
-  [234] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 3, 0, 0),
-  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [238] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_automated_xact, 5, 0, 0),
-  [240] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_automated_xact, 5, 0, 0),
-  [242] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_plain_xact_repeat1, 2, 0, 0),
-  [244] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_plain_xact_repeat1, 2, 0, 0),
-  [246] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_plain_xact_repeat1, 2, 0, 0), SHIFT_REPEAT(121),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 4, 0, 0),
-  [251] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 4, 0, 0),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_periodic_xact, 5, 0, 0),
-  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_periodic_xact, 5, 0, 0),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 5, 0, 0),
-  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 5, 0, 0),
-  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 7, 0, 0),
-  [263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 7, 0, 0),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 6, 0, 0),
-  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 6, 0, 0),
-  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 8, 0, 0),
-  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 8, 0, 0),
-  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_negative_quantity, 1, 0, 0),
-  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_negative_quantity, 1, 0, 0),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 10, 0, 0),
-  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 10, 0, 0),
-  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quantity, 1, 0, 0),
-  [283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quantity, 1, 0, 0),
-  [285] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 9, 0, 0),
-  [287] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 9, 0, 0),
-  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 4, 0, 0),
-  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 4, 0, 0),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
-  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
-  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
-  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_subdirective, 3, 0, 0),
-  [305] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_default_subdirective, 3, 0, 0),
-  [307] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_subdirective, 3, 0, 0),
-  [309] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_subdirective, 3, 0, 0),
-  [311] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_subdirective, 4, 0, 0),
-  [313] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_subdirective, 4, 0, 0),
-  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_subdirective, 4, 0, 0),
-  [317] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_check_subdirective, 4, 0, 0),
-  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 5, 0, 0),
-  [321] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 5, 0, 0),
-  [323] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_subdirective, 1, 0, 0),
-  [325] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_subdirective, 1, 0, 0),
-  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_subdirective, 4, 0, 0),
-  [329] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_subdirective, 4, 0, 0),
-  [331] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias_subdirective, 4, 0, 0),
-  [333] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_alias_subdirective, 4, 0, 0),
-  [335] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note_subdirective, 4, 0, 0),
-  [337] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_note_subdirective, 4, 0, 0),
-  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_subdirective, 4, 0, 0),
-  [341] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_format_subdirective, 4, 0, 0),
-  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 6, 0, 0),
-  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 6, 0, 0),
-  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 7, 0, 0),
-  [349] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 7, 0, 0),
-  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 8, 0, 0),
-  [353] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 8, 0, 0),
-  [355] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_subdirective, 1, 0, 0),
-  [357] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_subdirective, 1, 0, 0),
-  [359] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 10, 0, 0),
-  [361] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 10, 0, 0),
-  [363] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 11, 0, 0),
-  [365] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 11, 0, 0),
-  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 12, 0, 0),
-  [369] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 12, 0, 0),
-  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 13, 0, 0),
-  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 13, 0, 0),
-  [375] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 14, 0, 0),
-  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 14, 0, 0),
-  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 15, 0, 0),
-  [381] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 15, 0, 0),
-  [383] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 16, 0, 0),
-  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 16, 0, 0),
-  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity, 1, 0, 0),
-  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity, 1, 0, 0),
-  [391] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_plain_xact_repeat1, 3, 0, 0),
-  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_plain_xact_repeat1, 3, 0, 0),
-  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 3, 0, 0),
-  [397] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 3, 0, 0),
-  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 4, 0, 0),
-  [401] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 4, 0, 0),
-  [403] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 5, 0, 0),
-  [405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 5, 0, 0),
-  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 9, 0, 0),
-  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 9, 0, 0),
-  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 3, 0, 0),
-  [413] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 3, 0, 0),
-  [415] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
-  [417] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 5, 0, 0),
-  [419] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 5, 0, 0),
-  [421] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [423] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 5, 0, 0),
-  [425] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 5, 0, 0),
-  [427] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
-  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 4, 0, 0),
-  [431] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 4, 0, 0),
-  [433] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
-  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 6, 0, 0),
-  [437] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 6, 0, 0),
-  [439] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
-  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 6, 0, 0),
-  [443] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 6, 0, 0),
-  [445] = {.entry = {.count = 1, .reusable = false}}, SHIFT(90),
-  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 3, 0, 0),
-  [449] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 3, 0, 0),
-  [451] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [453] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 4, 0, 0),
-  [455] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 4, 0, 0),
-  [457] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
-  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_option, 3, 0, 0),
-  [461] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_option, 3, 0, 0),
-  [463] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xact, 1, 0, 0),
-  [465] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xact, 1, 0, 0),
-  [467] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_option, 5, 0, 0),
-  [469] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_option, 5, 0, 0),
-  [471] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 1, 0, 0),
-  [473] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 1, 0, 0),
-  [475] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_journal_item, 1, 0, 0),
-  [477] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_journal_item, 1, 0, 0),
-  [479] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 7, 0, 0),
-  [481] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 7, 0, 0),
-  [483] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2, 0, 0),
-  [485] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2, 0, 0),
-  [487] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 7, 0, 0),
-  [489] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 7, 0, 0),
-  [491] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [493] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [495] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [497] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
-  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(423),
-  [501] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [503] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [505] = {.entry = {.count = 1, .reusable = false}}, SHIFT(127),
-  [507] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [509] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
-  [511] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [513] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [515] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [517] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [519] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [521] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [523] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [525] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(98),
-  [528] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(99),
-  [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [533] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [535] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(105),
-  [538] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [540] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [542] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [544] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [546] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [548] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [550] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
-  [552] = {.entry = {.count = 1, .reusable = false}}, SHIFT(362),
-  [554] = {.entry = {.count = 1, .reusable = false}}, SHIFT(374),
-  [556] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [564] = {.entry = {.count = 1, .reusable = true}}, SHIFT(421),
-  [566] = {.entry = {.count = 1, .reusable = false}}, SHIFT(284),
-  [568] = {.entry = {.count = 1, .reusable = false}}, SHIFT(455),
-  [570] = {.entry = {.count = 1, .reusable = false}}, SHIFT(464),
-  [572] = {.entry = {.count = 1, .reusable = false}}, SHIFT(281),
-  [574] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [576] = {.entry = {.count = 1, .reusable = false}}, SHIFT(155),
-  [578] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [580] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [582] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [584] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(422),
-  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [592] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [594] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [596] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(396),
-  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
-  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(460),
-  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
-  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(387),
-  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
-  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
-  [620] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [622] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [624] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [626] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(152),
-  [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [631] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [633] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [635] = {.entry = {.count = 1, .reusable = true}}, SHIFT(445),
-  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(393),
-  [639] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
-  [642] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
-  [645] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
-  [647] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [649] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(157),
-  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [654] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
-  [656] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
-  [658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(459),
-  [660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(399),
-  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
-  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [666] = {.entry = {.count = 1, .reusable = false}}, SHIFT(491),
-  [668] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
-  [670] = {.entry = {.count = 1, .reusable = false}}, SHIFT(357),
-  [672] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [674] = {.entry = {.count = 1, .reusable = false}}, SHIFT(477),
-  [676] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [678] = {.entry = {.count = 1, .reusable = false}}, SHIFT(363),
-  [680] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
-  [682] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
-  [684] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
-  [686] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
-  [688] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__single_date, 3, 0, 0),
-  [690] = {.entry = {.count = 1, .reusable = true}}, SHIFT(462),
-  [692] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [694] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
-  [696] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [698] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [700] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
-  [702] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
-  [704] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [706] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
-  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [710] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
-  [712] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [714] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
-  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [718] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [720] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
-  [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
-  [732] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(185),
-  [735] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(477),
-  [738] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0),
-  [740] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(363),
-  [743] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
-  [745] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
-  [747] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(188),
-  [750] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(491),
-  [753] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(357),
-  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
-  [758] = {.entry = {.count = 1, .reusable = false}}, SHIFT(215),
-  [760] = {.entry = {.count = 1, .reusable = true}}, SHIFT(417),
-  [762] = {.entry = {.count = 1, .reusable = true}}, SHIFT(418),
-  [764] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lot_price, 3, 0, 0),
-  [766] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lot_price, 3, 0, 0),
-  [768] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lot_price, 4, 0, 0),
-  [770] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lot_price, 4, 0, 0),
-  [772] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
-  [774] = {.entry = {.count = 1, .reusable = false}}, SHIFT(250),
-  [776] = {.entry = {.count = 1, .reusable = false}}, SHIFT(224),
-  [778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(424),
-  [780] = {.entry = {.count = 1, .reusable = false}}, SHIFT(339),
-  [782] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 1, 0, 0),
-  [784] = {.entry = {.count = 1, .reusable = true}}, SHIFT(411),
-  [786] = {.entry = {.count = 1, .reusable = true}}, SHIFT(412),
-  [788] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [790] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
-  [792] = {.entry = {.count = 1, .reusable = true}}, SHIFT(415),
-  [794] = {.entry = {.count = 1, .reusable = true}}, SHIFT(416),
-  [796] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lot_price, 5, 0, 0),
-  [798] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lot_price, 5, 0, 0),
-  [800] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
-  [802] = {.entry = {.count = 1, .reusable = false}}, SHIFT(206),
-  [804] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__single_date, 5, 0, 0),
-  [806] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(216),
-  [809] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [811] = {.entry = {.count = 1, .reusable = false}}, SHIFT(210),
-  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
-  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(410),
-  [817] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [821] = {.entry = {.count = 1, .reusable = false}}, SHIFT(217),
-  [823] = {.entry = {.count = 1, .reusable = false}}, SHIFT(248),
-  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(405),
-  [827] = {.entry = {.count = 1, .reusable = false}}, SHIFT(343),
-  [829] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 2, 0, 0),
-  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
-  [833] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
-  [835] = {.entry = {.count = 1, .reusable = true}}, SHIFT(404),
-  [837] = {.entry = {.count = 1, .reusable = false}}, SHIFT(367),
-  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
-  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
-  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(332),
-  [845] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
-  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
-  [849] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
-  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [853] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__xact_date, 1, 0, 0),
-  [855] = {.entry = {.count = 1, .reusable = true}}, SHIFT(342),
-  [857] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_date, 1, 0, 0),
-  [859] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0),
-  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [863] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
-  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
-  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
-  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
-  [871] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
-  [873] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 3, 0, 0),
-  [875] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 3, 0, 0),
-  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [879] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
-  [881] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [883] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
-  [887] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [889] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
-  [891] = {.entry = {.count = 1, .reusable = false}}, SHIFT(226),
-  [893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(413),
-  [895] = {.entry = {.count = 1, .reusable = false}}, SHIFT(400),
-  [897] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0), SHIFT_REPEAT(248),
-  [900] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0),
-  [902] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0),
-  [904] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(250),
-  [907] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(250),
-  [910] = {.entry = {.count = 1, .reusable = false}}, SHIFT(467),
-  [912] = {.entry = {.count = 1, .reusable = false}}, SHIFT(355),
-  [914] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_price, 3, 0, 0),
-  [916] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 6, 0, 0),
-  [918] = {.entry = {.count = 1, .reusable = true}}, SHIFT(301),
-  [920] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [922] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [924] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0), SHIFT_REPEAT(261),
-  [927] = {.entry = {.count = 1, .reusable = true}}, SHIFT(390),
-  [929] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_date_spec, 1, 0, 0),
-  [931] = {.entry = {.count = 1, .reusable = true}}, SHIFT(454),
-  [933] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [935] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interval, 1, 0, 0),
-  [937] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [939] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account, 3, 0, 3),
-  [941] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [943] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 7, 0, 0),
-  [945] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
-  [947] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
-  [949] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account, 1, 0, 1),
-  [951] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_effective_date, 2, 0, 0),
-  [953] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_status, 1, 0, 0),
-  [955] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_status, 1, 0, 0),
-  [957] = {.entry = {.count = 1, .reusable = false}}, SHIFT(461),
-  [959] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [961] = {.entry = {.count = 1, .reusable = true}}, SHIFT(290),
-  [963] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_price, 2, 0, 0),
-  [965] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 4, 0, 0),
-  [967] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
-  [969] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
-  [971] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
-  [973] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 5, 0, 0),
-  [975] = {.entry = {.count = 1, .reusable = true}}, SHIFT(330),
-  [977] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__interval_date_spec, 3, 0, 0),
-  [979] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
-  [981] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [983] = {.entry = {.count = 1, .reusable = true}}, SHIFT(406),
-  [985] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
-  [987] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
-  [989] = {.entry = {.count = 1, .reusable = true}}, SHIFT(427),
-  [991] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
-  [993] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_balance_assertion, 2, 0, 0),
-  [995] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [997] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
-  [999] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
-  [1001] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [1003] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [1005] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
-  [1007] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [1009] = {.entry = {.count = 1, .reusable = false}}, SHIFT(444),
-  [1011] = {.entry = {.count = 1, .reusable = false}}, SHIFT(356),
-  [1013] = {.entry = {.count = 1, .reusable = false}}, SHIFT(472),
-  [1015] = {.entry = {.count = 1, .reusable = true}}, SHIFT(470),
-  [1017] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
-  [1019] = {.entry = {.count = 1, .reusable = true}}, SHIFT(472),
-  [1021] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [1023] = {.entry = {.count = 1, .reusable = true}}, SHIFT(480),
-  [1025] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
-  [1027] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
-  [1029] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_balance_assertion, 3, 0, 0),
-  [1031] = {.entry = {.count = 1, .reusable = true}}, SHIFT(431),
-  [1033] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [1035] = {.entry = {.count = 1, .reusable = true}}, SHIFT(327),
-  [1037] = {.entry = {.count = 1, .reusable = true}}, SHIFT(300),
-  [1039] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [1041] = {.entry = {.count = 1, .reusable = false}}, SHIFT(360),
-  [1043] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [1045] = {.entry = {.count = 1, .reusable = true}}, SHIFT(449),
-  [1047] = {.entry = {.count = 1, .reusable = true}}, SHIFT(314),
-  [1049] = {.entry = {.count = 1, .reusable = true}}, SHIFT(457),
-  [1051] = {.entry = {.count = 1, .reusable = true}}, SHIFT(487),
-  [1053] = {.entry = {.count = 1, .reusable = true}}, SHIFT(336),
-  [1055] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_code, 3, 0, 0),
-  [1057] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
-  [1059] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
-  [1061] = {.entry = {.count = 1, .reusable = true}}, SHIFT(447),
-  [1063] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
-  [1065] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(335),
-  [1068] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(337),
-  [1071] = {.entry = {.count = 1, .reusable = false}}, SHIFT(476),
-  [1073] = {.entry = {.count = 1, .reusable = false}}, SHIFT(335),
-  [1075] = {.entry = {.count = 1, .reusable = false}}, SHIFT(344),
-  [1077] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__relative_date_spec, 3, 0, 0),
-  [1079] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
-  [1081] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 3, 0, 0),
-  [1083] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_note_repeat2, 2, 0, 0), SHIFT_REPEAT(344),
-  [1086] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_note_repeat2, 2, 0, 0),
-  [1088] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__xact_date, 2, 0, 0),
-  [1090] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [1092] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [1094] = {.entry = {.count = 1, .reusable = false}}, SHIFT(350),
-  [1096] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 4, 0, 0),
-  [1098] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [1100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 5, 0, 0),
-  [1102] = {.entry = {.count = 1, .reusable = false}}, SHIFT(352),
-  [1104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 6, 0, 0),
-  [1106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(486),
-  [1108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [1110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
-  [1112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(355),
-  [1115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(356),
-  [1118] = {.entry = {.count = 1, .reusable = false}}, SHIFT(434),
-  [1120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(425),
-  [1122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(329),
-  [1124] = {.entry = {.count = 1, .reusable = false}}, SHIFT(394),
-  [1126] = {.entry = {.count = 1, .reusable = false}}, SHIFT(337),
-  [1128] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(360),
-  [1131] = {.entry = {.count = 1, .reusable = false}}, SHIFT(481),
-  [1133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [1135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(338),
-  [1137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
-  [1139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
-  [1141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
-  [1143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
-  [1145] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_note_repeat2, 2, 0, 0), SHIFT_REPEAT(369),
-  [1148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
-  [1150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [1152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
-  [1154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [1156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [1158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(328),
-  [1160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
-  [1162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [1164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
-  [1166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
-  [1168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [1170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
-  [1172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
-  [1174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [1176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
-  [1178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(398),
-  [1180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [1182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
-  [1184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
-  [1186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
-  [1188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [1190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
-  [1192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
-  [1194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [1196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
-  [1198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
-  [1200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
-  [1202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
-  [1204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
-  [1206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
-  [1208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(461),
-  [1210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__interval_date_spec, 1, 0, 2),
-  [1212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interval, 3, 0, 0),
-  [1214] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__interval_date_spec, 7, 0, 0),
-  [1216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [1218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 8, 0, 0),
-  [1220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(388),
-  [1222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [1224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [1226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_out, 4, 0, 0),
-  [1228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(295),
-  [1230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
-  [1232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(297),
-  [1234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_directive, 5, 0, 0),
-  [1236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
-  [1238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [1240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [1242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(331),
-  [1244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(488),
-  [1246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(474),
-  [1248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [1250] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [1252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_out, 3, 0, 0),
-  [1254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(385),
-  [1256] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 10, 0, 0),
-  [1258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 6, 0, 0),
-  [1260] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
-  [1262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(475),
-  [1264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(452),
-  [1266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 3, 0, 0),
-  [1268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_directive, 1, 0, 0),
-  [1270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(441),
-  [1272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [1274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_option_value, 1, 0, 0),
-  [1276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
-  [1278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 1, 0, 0),
-  [1280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(473),
-  [1282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 5, 0, 0),
-  [1284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_filename, 1, 0, 0),
-  [1286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
-  [1288] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 9, 0, 0),
-  [1290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [1292] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_directive, 3, 0, 0),
-  [1294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(436),
-  [1296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [1298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
-  [1300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [1302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_out, 5, 0, 0),
-  [1304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [1306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 7, 0, 0),
-  [1308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
-  [1310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
-  [1312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [1314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [1316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
-  [1318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(295),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(413),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(413),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(385),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(441),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(360),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
+  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
+  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(154),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
+  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(412),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [69] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
+  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(76),
+  [75] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(302),
+  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(409),
+  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(295),
+  [84] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(413),
+  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(413),
+  [90] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(385),
+  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(355),
+  [96] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(374),
+  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(361),
+  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(362),
+  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(381),
+  [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(383),
+  [111] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(384),
+  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(386),
+  [117] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(441),
+  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(372),
+  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(360),
+  [126] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(363),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(366),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(369),
+  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(370),
+  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(371),
+  [141] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(154),
+  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(154),
+  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
+  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(373),
+  [153] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(412),
+  [156] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_directive, 5, 0, 0),
+  [158] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_directive, 5, 0, 0),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [162] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_directive, 4, 0, 0),
+  [164] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_directive, 4, 0, 0),
+  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_account_directive_repeat1, 2, 0, 0),
+  [168] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_account_directive_repeat1, 2, 0, 0),
+  [170] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_account_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(129),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_directive, 4, 0, 0),
+  [175] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_directive, 4, 0, 0),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_commodity_directive_repeat1, 2, 0, 0),
+  [181] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_commodity_directive_repeat1, 2, 0, 0),
+  [183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_commodity_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(148),
+  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_directive, 5, 0, 0),
+  [188] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_directive, 5, 0, 0),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0),
+  [192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
+  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_payee_directive, 4, 0, 0),
+  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_payee_directive, 4, 0, 0),
+  [199] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag_directive, 4, 0, 0),
+  [203] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag_directive, 4, 0, 0),
+  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag_directive, 3, 0, 0),
+  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag_directive, 3, 0, 0),
+  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_payee_directive, 5, 0, 0),
+  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_payee_directive, 5, 0, 0),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_payee_directive_repeat1, 2, 0, 0),
+  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_payee_directive_repeat1, 2, 0, 0),
+  [219] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_payee_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(214),
+  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_tag_directive_repeat1, 2, 0, 0),
+  [224] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_tag_directive_repeat1, 2, 0, 0),
+  [226] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_tag_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(234),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_plain_xact_repeat1, 2, 0, 0),
+  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_plain_xact_repeat1, 2, 0, 0),
+  [233] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_plain_xact_repeat1, 2, 0, 0), SHIFT_REPEAT(125),
+  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 4, 0, 0),
+  [238] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 4, 0, 0),
+  [240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [242] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 3, 0, 0),
+  [244] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 3, 0, 0),
+  [246] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_automated_xact, 5, 0, 0),
+  [248] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_automated_xact, 5, 0, 0),
+  [250] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 5, 0, 0),
+  [252] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 5, 0, 0),
+  [254] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_periodic_xact, 5, 0, 0),
+  [256] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_periodic_xact, 5, 0, 0),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 6, 0, 0),
+  [260] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 6, 0, 0),
+  [262] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 8, 0, 0),
+  [264] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 8, 0, 0),
+  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 9, 0, 0),
+  [268] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 9, 0, 0),
+  [270] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 7, 0, 0),
+  [272] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 7, 0, 0),
+  [274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_plain_xact, 10, 0, 0),
+  [276] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_plain_xact, 10, 0, 0),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 13, 0, 0),
+  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 13, 0, 0),
+  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 3, 0, 0),
+  [284] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 3, 0, 0),
+  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_subdirective, 1, 0, 0),
+  [288] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_subdirective, 1, 0, 0),
+  [290] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 4, 0, 0),
+  [292] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 4, 0, 0),
+  [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_payee_subdirective, 1, 0, 0),
+  [296] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_payee_subdirective, 1, 0, 0),
+  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_subdirective, 3, 0, 0),
+  [300] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_default_subdirective, 3, 0, 0),
+  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_subdirective, 3, 0, 0),
+  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_subdirective, 3, 0, 0),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_subdirective, 4, 0, 0),
+  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_subdirective, 4, 0, 0),
+  [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_plain_xact_repeat1, 3, 0, 0),
+  [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_plain_xact_repeat1, 3, 0, 0),
+  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 5, 0, 0),
+  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 5, 0, 0),
+  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account_subdirective, 4, 0, 0),
+  [320] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_account_subdirective, 4, 0, 0),
+  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alias_subdirective, 4, 0, 0),
+  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_alias_subdirective, 4, 0, 0),
+  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note_subdirective, 4, 0, 0),
+  [328] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_note_subdirective, 4, 0, 0),
+  [330] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_payee_subdirective, 4, 0, 0),
+  [332] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_payee_subdirective, 4, 0, 0),
+  [334] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 6, 0, 0),
+  [336] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 6, 0, 0),
+  [338] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity_subdirective, 1, 0, 0),
+  [340] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity_subdirective, 1, 0, 0),
+  [342] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_subdirective, 5, 0, 0),
+  [344] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_format_subdirective, 5, 0, 0),
+  [346] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 7, 0, 0),
+  [348] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 7, 0, 0),
+  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 8, 0, 0),
+  [352] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 8, 0, 0),
+  [354] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 9, 0, 0),
+  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 9, 0, 0),
+  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 10, 0, 0),
+  [360] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 10, 0, 0),
+  [362] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 11, 0, 0),
+  [364] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 11, 0, 0),
+  [366] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 12, 0, 0),
+  [368] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 12, 0, 0),
+  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 14, 0, 0),
+  [372] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 14, 0, 0),
+  [374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 15, 0, 0),
+  [376] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 15, 0, 0),
+  [378] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_posting, 16, 0, 0),
+  [380] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_posting, 16, 0, 0),
+  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_subdirective, 4, 0, 0),
+  [384] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_check_subdirective, 4, 0, 0),
+  [386] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 5, 0, 0),
+  [388] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 5, 0, 0),
+  [390] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [392] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 6, 0, 0),
+  [394] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 6, 0, 0),
+  [396] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [398] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 4, 0, 0),
+  [400] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 4, 0, 0),
+  [402] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [404] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 6, 0, 0),
+  [406] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 6, 0, 0),
+  [408] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [410] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 3, 0, 0),
+  [412] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 3, 0, 0),
+  [414] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [416] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 4, 0, 0),
+  [418] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 4, 0, 0),
+  [420] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
+  [424] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
+  [426] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [430] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 3, 0, 0),
+  [434] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 3, 0, 0),
+  [436] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [438] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 5, 0, 0),
+  [440] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 5, 0, 0),
+  [442] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [444] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 1, 0, 0),
+  [446] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 1, 0, 0),
+  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_option, 3, 0, 0),
+  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_option, 3, 0, 0),
+  [452] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_option, 5, 0, 0),
+  [454] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_option, 5, 0, 0),
+  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_journal_item, 1, 0, 0),
+  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_journal_item, 1, 0, 0),
+  [460] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xact, 1, 0, 0),
+  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xact, 1, 0, 0),
+  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_comment, 7, 0, 0),
+  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block_comment, 7, 0, 0),
+  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test, 7, 0, 0),
+  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test, 7, 0, 0),
+  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2, 0, 0),
+  [474] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2, 0, 0),
+  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [480] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [482] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
+  [484] = {.entry = {.count = 1, .reusable = true}}, SHIFT(407),
+  [486] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [488] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [490] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
+  [492] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [494] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [502] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [504] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [506] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [508] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [510] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0),
+  [512] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(90),
+  [515] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(91),
+  [518] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commodity, 1, 0, 0),
+  [520] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commodity, 1, 0, 0),
+  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 2, 0, 0),
+  [524] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 2, 0, 0),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [528] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 3, 0, 0),
+  [530] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 3, 0, 0),
+  [532] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 1, 0, 0),
+  [534] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 1, 0, 0),
+  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [538] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(97),
+  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [543] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quantity, 1, 0, 0),
+  [545] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quantity, 1, 0, 0),
+  [547] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_negative_quantity, 1, 0, 0),
+  [551] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_negative_quantity, 1, 0, 0),
+  [553] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [555] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [559] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [561] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
+  [563] = {.entry = {.count = 1, .reusable = false}}, SHIFT(343),
+  [565] = {.entry = {.count = 1, .reusable = false}}, SHIFT(368),
+  [567] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [569] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [571] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [575] = {.entry = {.count = 1, .reusable = true}}, SHIFT(398),
+  [577] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
+  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [583] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [585] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [587] = {.entry = {.count = 1, .reusable = false}}, SHIFT(278),
+  [589] = {.entry = {.count = 1, .reusable = false}}, SHIFT(434),
+  [591] = {.entry = {.count = 1, .reusable = false}}, SHIFT(411),
+  [593] = {.entry = {.count = 1, .reusable = false}}, SHIFT(243),
+  [595] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [597] = {.entry = {.count = 1, .reusable = false}}, SHIFT(151),
+  [599] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [601] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [603] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(377),
+  [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(378),
+  [609] = {.entry = {.count = 1, .reusable = true}}, SHIFT(438),
+  [611] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
+  [613] = {.entry = {.count = 1, .reusable = true}}, SHIFT(375),
+  [615] = {.entry = {.count = 1, .reusable = true}}, SHIFT(376),
+  [617] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [619] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [621] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [623] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [625] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 4, 0, 0),
+  [627] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 4, 0, 0),
+  [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [631] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [633] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [635] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_amount, 5, 0, 0),
+  [637] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_amount, 5, 0, 0),
+  [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [641] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [643] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(145),
+  [646] = {.entry = {.count = 1, .reusable = false}}, SHIFT(348),
+  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(461),
+  [654] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
+  [656] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(149),
+  [659] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
+  [661] = {.entry = {.count = 1, .reusable = true}}, SHIFT(464),
+  [663] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
+  [665] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [667] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(151),
+  [670] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(151),
+  [673] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [675] = {.entry = {.count = 1, .reusable = false}}, SHIFT(472),
+  [677] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [679] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
+  [681] = {.entry = {.count = 1, .reusable = false}}, SHIFT(324),
+  [683] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__single_date, 3, 0, 0),
+  [685] = {.entry = {.count = 1, .reusable = true}}, SHIFT(445),
+  [687] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [689] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [691] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [693] = {.entry = {.count = 1, .reusable = false}}, SHIFT(466),
+  [695] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [697] = {.entry = {.count = 1, .reusable = false}}, SHIFT(338),
+  [699] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(157),
+  [702] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(472),
+  [705] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0),
+  [707] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(324),
+  [710] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [712] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [714] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [718] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [722] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
+  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [734] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [736] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
+  [738] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [740] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [742] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [744] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(174),
+  [747] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(466),
+  [750] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(338),
+  [753] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [755] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [757] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
+  [759] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(176),
+  [762] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
+  [764] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [766] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
+  [768] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [770] = {.entry = {.count = 1, .reusable = false}}, SHIFT(229),
+  [772] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [774] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
+  [776] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__single_date, 5, 0, 0),
+  [778] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lot_price, 4, 0, 0),
+  [780] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lot_price, 4, 0, 0),
+  [782] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lot_price, 5, 0, 0),
+  [784] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lot_price, 5, 0, 0),
+  [786] = {.entry = {.count = 1, .reusable = false}}, SHIFT(202),
+  [788] = {.entry = {.count = 1, .reusable = true}}, SHIFT(408),
+  [790] = {.entry = {.count = 1, .reusable = false}}, SHIFT(330),
+  [792] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 1, 0, 0),
+  [794] = {.entry = {.count = 1, .reusable = false}}, SHIFT(226),
+  [796] = {.entry = {.count = 1, .reusable = true}}, SHIFT(402),
+  [798] = {.entry = {.count = 1, .reusable = false}}, SHIFT(335),
+  [800] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 2, 0, 0),
+  [802] = {.entry = {.count = 1, .reusable = true}}, SHIFT(405),
+  [804] = {.entry = {.count = 1, .reusable = true}}, SHIFT(406),
+  [806] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
+  [808] = {.entry = {.count = 1, .reusable = true}}, SHIFT(401),
+  [810] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
+  [812] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [814] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
+  [816] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lot_price, 3, 0, 0),
+  [818] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lot_price, 3, 0, 0),
+  [820] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [822] = {.entry = {.count = 1, .reusable = false}}, SHIFT(181),
+  [824] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
+  [826] = {.entry = {.count = 1, .reusable = false}}, SHIFT(208),
+  [828] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
+  [830] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [832] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
+  [834] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 3, 0, 0),
+  [836] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_comment_repeat1, 3, 0, 0),
+  [838] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [840] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
+  [842] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_comment_repeat1, 2, 0, 0),
+  [844] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
+  [846] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [848] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
+  [850] = {.entry = {.count = 1, .reusable = false}}, SHIFT(224),
+  [852] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
+  [854] = {.entry = {.count = 1, .reusable = false}}, SHIFT(352),
+  [856] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
+  [858] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [860] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
+  [862] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
+  [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(395),
+  [866] = {.entry = {.count = 1, .reusable = false}}, SHIFT(358),
+  [868] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
+  [870] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0), SHIFT_REPEAT(226),
+  [873] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0),
+  [875] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0),
+  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
+  [879] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(229),
+  [882] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(229),
+  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(258),
+  [887] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
+  [889] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [891] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__xact_date, 1, 0, 0),
+  [893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
+  [895] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [897] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [899] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
+  [901] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
+  [903] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [905] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
+  [907] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
+  [909] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_date, 1, 0, 0),
+  [911] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 7, 0, 0),
+  [913] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
+  [915] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_effective_date, 2, 0, 0),
+  [917] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account, 1, 0, 1),
+  [919] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 6, 0, 0),
+  [921] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
+  [923] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
+  [925] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [927] = {.entry = {.count = 1, .reusable = true}}, SHIFT(394),
+  [929] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
+  [931] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [933] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
+  [935] = {.entry = {.count = 1, .reusable = false}}, SHIFT(467),
+  [937] = {.entry = {.count = 1, .reusable = false}}, SHIFT(346),
+  [939] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 4, 0, 0),
+  [941] = {.entry = {.count = 1, .reusable = true}}, SHIFT(333),
+  [943] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_price, 2, 0, 0),
+  [945] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [947] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [949] = {.entry = {.count = 1, .reusable = false}}, SHIFT(431),
+  [951] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_note_repeat1, 2, 0, 0), SHIFT_REPEAT(261),
+  [954] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_account, 3, 0, 3),
+  [956] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interval, 1, 0, 0),
+  [958] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [960] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
+  [962] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_status, 1, 0, 0),
+  [964] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_status, 1, 0, 0),
+  [966] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 5, 0, 0),
+  [968] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
+  [970] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__interval_date_spec, 3, 0, 0),
+  [972] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
+  [974] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_date_spec, 1, 0, 0),
+  [976] = {.entry = {.count = 1, .reusable = true}}, SHIFT(442),
+  [978] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [980] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_price, 3, 0, 0),
+  [982] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [984] = {.entry = {.count = 1, .reusable = false}}, SHIFT(349),
+  [986] = {.entry = {.count = 1, .reusable = false}}, SHIFT(476),
+  [988] = {.entry = {.count = 1, .reusable = true}}, SHIFT(476),
+  [990] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [992] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
+  [994] = {.entry = {.count = 1, .reusable = true}}, SHIFT(450),
+  [996] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
+  [998] = {.entry = {.count = 1, .reusable = true}}, SHIFT(469),
+  [1000] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [1002] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [1004] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [1006] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
+  [1008] = {.entry = {.count = 1, .reusable = false}}, SHIFT(357),
+  [1010] = {.entry = {.count = 1, .reusable = false}}, SHIFT(329),
+  [1012] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_balance_assertion, 3, 0, 0),
+  [1014] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [1016] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
+  [1018] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
+  [1020] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
+  [1022] = {.entry = {.count = 1, .reusable = true}}, SHIFT(328),
+  [1024] = {.entry = {.count = 1, .reusable = true}}, SHIFT(382),
+  [1026] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [1028] = {.entry = {.count = 1, .reusable = true}}, SHIFT(430),
+  [1030] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [1032] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [1034] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
+  [1036] = {.entry = {.count = 1, .reusable = true}}, SHIFT(443),
+  [1038] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [1040] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [1042] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [1044] = {.entry = {.count = 1, .reusable = true}}, SHIFT(294),
+  [1046] = {.entry = {.count = 1, .reusable = true}}, SHIFT(345),
+  [1048] = {.entry = {.count = 1, .reusable = true}}, SHIFT(424),
+  [1050] = {.entry = {.count = 1, .reusable = true}}, SHIFT(419),
+  [1052] = {.entry = {.count = 1, .reusable = true}}, SHIFT(416),
+  [1054] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
+  [1056] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [1058] = {.entry = {.count = 1, .reusable = true}}, SHIFT(456),
+  [1060] = {.entry = {.count = 1, .reusable = false}}, SHIFT(453),
+  [1062] = {.entry = {.count = 1, .reusable = false}}, SHIFT(347),
+  [1064] = {.entry = {.count = 1, .reusable = true}}, SHIFT(320),
+  [1066] = {.entry = {.count = 1, .reusable = false}}, SHIFT(457),
+  [1068] = {.entry = {.count = 1, .reusable = false}}, SHIFT(337),
+  [1070] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [1072] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_balance_assertion, 2, 0, 0),
+  [1074] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
+  [1076] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
+  [1078] = {.entry = {.count = 1, .reusable = false}}, SHIFT(433),
+  [1080] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(329),
+  [1083] = {.entry = {.count = 1, .reusable = false}}, SHIFT(336),
+  [1085] = {.entry = {.count = 1, .reusable = true}}, SHIFT(300),
+  [1087] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__xact_date, 2, 0, 0),
+  [1089] = {.entry = {.count = 1, .reusable = true}}, SHIFT(429),
+  [1091] = {.entry = {.count = 1, .reusable = true}}, SHIFT(317),
+  [1093] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_code, 3, 0, 0),
+  [1095] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 3, 0, 0),
+  [1097] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_note_repeat2, 2, 0, 0), SHIFT_REPEAT(336),
+  [1100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_note_repeat2, 2, 0, 0),
+  [1102] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(337),
+  [1105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(468),
+  [1107] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
+  [1109] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 4, 0, 0),
+  [1111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 5, 0, 0),
+  [1113] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
+  [1115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_note, 6, 0, 0),
+  [1117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
+  [1119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(454),
+  [1121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(346),
+  [1124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(347),
+  [1127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__relative_date_spec, 3, 0, 0),
+  [1129] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_whitespace_repeat1, 2, 0, 0), SHIFT_REPEAT(349),
+  [1132] = {.entry = {.count = 1, .reusable = false}}, SHIFT(425),
+  [1134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(290),
+  [1136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [1138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
+  [1140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [1142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [1144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
+  [1146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [1148] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_note_repeat2, 2, 0, 0), SHIFT_REPEAT(359),
+  [1151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
+  [1153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [1155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
+  [1157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
+  [1159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [1161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [1163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [1165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [1167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [1169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [1171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [1173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [1175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [1177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [1179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
+  [1181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
+  [1183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
+  [1185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
+  [1187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
+  [1189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
+  [1191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
+  [1193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
+  [1195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
+  [1197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
+  [1199] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
+  [1201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
+  [1203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [1205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
+  [1207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(387),
+  [1209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [1211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(431),
+  [1213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__interval_date_spec, 7, 0, 0),
+  [1215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__interval_date_spec, 1, 0, 2),
+  [1217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interval, 3, 0, 0),
+  [1219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_directive, 1, 0, 0),
+  [1221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(477),
+  [1223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(422),
+  [1225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [1227] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [1229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 7, 0, 0),
+  [1231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_out, 3, 0, 0),
+  [1233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
+  [1235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 6, 0, 0),
+  [1237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_directive, 5, 0, 0),
+  [1239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [1241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [1243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [1245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(390),
+  [1247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(421),
+  [1249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 10, 0, 0),
+  [1251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_option_value, 1, 0, 0),
+  [1253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [1255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [1257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(444),
+  [1259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [1261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [1263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [1265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 5, 0, 0),
+  [1267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [1269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(458),
+  [1271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_out, 4, 0, 0),
+  [1273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
+  [1275] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [1277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
+  [1279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
+  [1281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 9, 0, 0),
+  [1283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [1285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [1287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(427),
+  [1289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_out, 5, 0, 0),
+  [1291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [1293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_check_in, 8, 0, 0),
+  [1295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
+  [1297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [1299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [1301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
+  [1303] = {.entry = {.count = 1, .reusable = true}}, SHIFT(463),
+  [1305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
+  [1307] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_filename, 1, 0, 0),
+  [1309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
+  [1311] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 3, 0, 0),
+  [1313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
+  [1315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
+  [1317] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [1319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char_directive, 1, 0, 0),
+  [1321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [1323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [1325] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word_directive, 3, 0, 0),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/directives.txt
+++ b/test/corpus/directives.txt
@@ -102,6 +102,27 @@ commodity $
           (alias_subdirective))))))
 
 ================================================================================
+payee with subdirectives
+================================================================================
+
+payee KFC
+    alias KENTUCKY FRIED CHICKEN
+    ; comment
+    uuid 2a2e21d434356f886c84371eebac6e44f1337fda
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (journal_item
+    (directive
+      (payee_directive
+        (payee)
+        (payee_subdirective
+          (alias_subdirective))
+        (comment)
+        (payee_subdirective)))))
+
+================================================================================
 alias declaration
 ================================================================================
 

--- a/test/corpus/directives.txt
+++ b/test/corpus/directives.txt
@@ -63,6 +63,39 @@ account Assets:Bank
           (note_subdirective))))))
 
 ================================================================================
+account with all subdirectives
+================================================================================
+
+account Expenses:Food
+    note This account is all about the chicken!
+    alias food
+    payee ^(KFC|Popeyes)$
+    check commodity == "$"
+    assert commodity == "$"
+    eval print("Hello!")
+    default
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (journal_item
+    (directive
+      (account_directive
+        (account)
+        (account_subdirective
+          (note_subdirective))
+        (account_subdirective
+          (alias_subdirective))
+        (account_subdirective)
+        (account_subdirective
+          (check_subdirective))
+        (account_subdirective
+          (assert_subdirective))
+        (account_subdirective)
+        (account_subdirective
+          (default_subdirective))))))
+
+================================================================================
 commodity with format
 ================================================================================
 
@@ -100,6 +133,37 @@ commodity $
         (comment)
         (commodity_subdirective
           (alias_subdirective))))))
+
+================================================================================
+commodity with all subdirectives
+================================================================================
+
+commodity $
+   note American Dollars
+   format $1,000.00
+   nomarket
+   alias USD
+   default
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (journal_item
+    (directive
+      (commodity_directive
+        (commodity)
+        (commodity_subdirective
+          (note_subdirective))
+        (commodity_subdirective
+          (format_subdirective
+            (amount
+              (commodity)
+              (quantity))))
+        (commodity_subdirective)
+        (commodity_subdirective
+          (alias_subdirective))
+        (commodity_subdirective
+          (default_subdirective))))))
 
 ================================================================================
 payee with subdirectives


### PR DESCRIPTION
This does 3 things:
- adds support for the `payee` directive, which seems to not be supported at all on master
- fixes an issue with the `format` subdirective of `commodity`
- adds a test for `payee` and adds additional tests for `account` & `commodity`, all taken directly from the ledger docs
  - `account` works as expected w/o changes
  - `commodity` uncovered an issue with `format` subdirective support (fixed)
  - `payee` was not supported at all

Regeneration was done via `npm run generate`.